### PR TITLE
analyzeCommandでHashとsendを使うように

### DIFF
--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -745,107 +745,101 @@ class DodontoFServer
     if( commandName.nil? or commandName.empty? )
       return getResponseTextWhenNoCommandName
     end
-    
-    hasReturn = "hasReturn";
-    hasNoReturn = "hasNoReturn";
-    
-    commands = [
-      ['refresh', hasReturn],
-      
-      ['getGraveyardCharacterData', hasReturn], 
-      ['resurrectCharacter', hasReturn], 
-      ['clearGraveyard', hasReturn], 
-      ['getLoginInfo', hasReturn], 
-      ['getPlayRoomStates', hasReturn], 
-      ['deleteImage', hasReturn], 
-      ['uploadImageUrl', hasReturn], 
-      ['save', hasReturn], 
-      ['saveMap', hasReturn], 
-      ['saveAllData', hasReturn], 
-      ['load', hasReturn], 
-      ['loadAllSaveData', hasReturn], 
-      ['getDiceBotInfos', hasReturn], 
-      ['getBotTableInfos', hasReturn], 
-      ['addBotTable', hasReturn], 
-      ['changeBotTable', hasReturn], 
-      ['removeBotTable', hasReturn], 
-      ['requestReplayDataList', hasReturn], 
-      ['uploadReplayData', hasReturn], 
-      ['removeReplayData', hasReturn], 
-      ['checkRoomStatus', hasReturn], 
-      ['loginPassword', hasReturn], 
-      ['uploadFile', hasReturn], 
-      ['uploadImageData', hasReturn], 
-      ['createPlayRoom', hasReturn], 
-      ['changePlayRoom', hasReturn], 
-      ['removePlayRoom', hasReturn], 
-      ['removeOldPlayRoom', hasReturn], 
-      ['getImageTagsAndImageList', hasReturn], 
-      ['addCharacter', hasReturn],
-      ['getWaitingRoomInfo', hasReturn], 
-      ['exitWaitingRoomCharacter', hasReturn],
-      ['enterWaitingRoomCharacter', hasReturn], 
-      ['sendDiceBotChatMessage', hasReturn],
-      ['deleteChatLog', hasReturn], 
-      ['sendChatMessageAll', hasReturn],
-      ['undoDrawOnMap', hasReturn],
-      
-      ['logout', hasNoReturn], 
-      ['changeCharacter', hasNoReturn],
-      ['removeCharacter', hasNoReturn],
-      
+
+    commands = {
+      'refresh' => :hasReturn,
+
+      'getGraveyardCharacterData' => :hasReturn,
+      'resurrectCharacter' => :hasReturn,
+      'clearGraveyard' => :hasReturn,
+      'getLoginInfo' => :hasReturn,
+      'getPlayRoomStates' => :hasReturn,
+      'deleteImage' => :hasReturn,
+      'uploadImageUrl' => :hasReturn,
+      'save' => :hasReturn,
+      'saveMap' => :hasReturn,
+      'saveAllData' => :hasReturn,
+      'load' => :hasReturn,
+      'loadAllSaveData' => :hasReturn,
+      'getDiceBotInfos' => :hasReturn,
+      'getBotTableInfos' => :hasReturn,
+      'addBotTable' => :hasReturn,
+      'changeBotTable' => :hasReturn,
+      'removeBotTable' => :hasReturn,
+      'requestReplayDataList' => :hasReturn,
+      'uploadReplayData' => :hasReturn,
+      'removeReplayData' => :hasReturn,
+      'checkRoomStatus' => :hasReturn,
+      'loginPassword' => :hasReturn,
+      'uploadFile' => :hasReturn,
+      'uploadImageData' => :hasReturn,
+      'createPlayRoom' => :hasReturn,
+      'changePlayRoom' => :hasReturn,
+      'removePlayRoom' => :hasReturn,
+      'removeOldPlayRoom' => :hasReturn,
+      'getImageTagsAndImageList' => :hasReturn,
+      'addCharacter' => :hasReturn,
+      'getWaitingRoomInfo' => :hasReturn,
+      'exitWaitingRoomCharacter' => :hasReturn,
+      'enterWaitingRoomCharacter' => :hasReturn,
+      'sendDiceBotChatMessage' => :hasReturn,
+      'deleteChatLog' => :hasReturn,
+      'sendChatMessageAll' => :hasReturn,
+      'undoDrawOnMap' => :hasReturn,
+
+      'logout' => :hasNoReturn,
+      'changeCharacter' => :hasNoReturn,
+      'removeCharacter' => :hasNoReturn,
+
       # Card Command Get
-      ['getMountCardInfos', hasReturn],
-      ['getTrushMountCardInfos', hasReturn],
-      ['getCardList', hasReturn],
-      
+      'getMountCardInfos' => :hasReturn,
+      'getTrushMountCardInfos' => :hasReturn,
+      'getCardList' => :hasReturn,
+
       # Card Command Set
-      ['drawTargetCard', hasReturn],
-      ['drawTargetTrushCard', hasReturn],
-      ['drawCard', hasReturn],
-      ['addCard', hasNoReturn],
-      ['addCardZone', hasNoReturn],
-      ['initCards', hasReturn],
-      ['returnCard', hasNoReturn],
-      ['shuffleCards', hasNoReturn],
-      ['shuffleOnlyMountCards', hasNoReturn],
-      ['shuffleForNextRandomDungeon', hasNoReturn],
-      ['dumpTrushCards', hasNoReturn],
-      ['returnCardToMount', hasNoReturn],
-      
-      ['clearCharacterByType', hasNoReturn],
-      ['moveCharacter', hasNoReturn],
-      ['changeMap', hasNoReturn],
-      ['drawOnMap', hasNoReturn],
-      ['clearDrawOnMap', hasNoReturn],
-      ['sendChatMessage', hasNoReturn],
-      ['changeRoundTime', hasNoReturn],
-      ['addResource', hasNoReturn],
-      ['changeResource', hasNoReturn],
-      ['changeResourcesAll', hasNoReturn],
-      ['removeResource', hasNoReturn],
-      ['addEffect', hasNoReturn], 
-      ['changeEffect', hasNoReturn], 
-      ['changeEffectsAll', hasNoReturn], 
-      ['removeEffect', hasNoReturn], 
-      ['changeImageTags', hasNoReturn], 
-    ]
-    
-    commands.each do |command, commandType|
-      next unless( command == commandName )
-      logging(commandType, "commandType")
-      
-      case commandType
-      when hasReturn
-        return eval( command )
-      when hasNoReturn
-        eval( command )
-        return nil
-      end
+      'drawTargetCard' => :hasReturn,
+      'drawTargetTrushCard' => :hasReturn,
+      'drawCard' => :hasReturn,
+      'addCard' => :hasNoReturn,
+      'addCardZone' => :hasNoReturn,
+      'initCards' => :hasReturn,
+      'returnCard' => :hasNoReturn,
+      'shuffleCards' => :hasNoReturn,
+      'shuffleOnlyMountCards' => :hasNoReturn,
+      'shuffleForNextRandomDungeon' => :hasNoReturn,
+      'dumpTrushCards' => :hasNoReturn,
+      'returnCardToMount' => :hasNoReturn,
+
+      'clearCharacterByType' => :hasNoReturn,
+      'moveCharacter' => :hasNoReturn,
+      'changeMap' => :hasNoReturn,
+      'drawOnMap' => :hasNoReturn,
+      'clearDrawOnMap' => :hasNoReturn,
+      'sendChatMessage' => :hasNoReturn,
+      'changeRoundTime' => :hasNoReturn,
+      'addResource' => :hasNoReturn,
+      'changeResource' => :hasNoReturn,
+      'changeResourcesAll' => :hasNoReturn,
+      'removeResource' => :hasNoReturn,
+      'addEffect' => :hasNoReturn,
+      'changeEffect' => :hasNoReturn,
+      'changeEffectsAll' => :hasNoReturn,
+      'removeEffect' => :hasNoReturn,
+      'changeImageTags' => :hasNoReturn
+    }
+
+    commandType = commands[commandName]
+    logging(commandType, "commandType")
+
+    case commandType
+    when :hasReturn
+      return self.send( commandName )
+    when :hasNoReturn
+      self.send( commandName )
+      return nil
+    else
+      throw Exception.new("\"" + commandName.untaint + "\" is invalid command")
     end
-    
-    throw Exception.new("\"" + commandName.untaint + "\" is invalid command")
-    
   end
   
   def getResponseTextWhenNoCommandName


### PR DESCRIPTION
このPull Requestは**可読性**の向上、及び若干の**実行速度向上**を目的としたものです。

速度向上の根拠となるベンチマーク用のコードは[gist](https://gist.github.com/NKMR6194/da5b9b1c30c28b2899dcdc96691cb197)にアップロードしました。

変更部分の速度向上は確認していますが、全体から見た割合は低いとみられるため、体感としてはあまり変わらないかと思います。

## 主な変更点

### コマンドの探索をHashにまかせる

コマンドの探索をHashにまかせることで処理が簡潔になりました。さらに、従来の探索方式よりも高速になっています。

### eval を send に

`send`を用いると文字列及びシンボルで指定したメソッドを呼び出すことができます。従来通り`eval`でも可能ですが、`eval`を実行するとパース処理なども実行されオーバーヘッドが大きいため、`send`の方が高速に動作します。また、関数を呼び出しているということも明確になります。