### PR TITLE
APIテストを実装した

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.temp
+/test_log.txt

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -45,6 +45,10 @@ begin
 rescue Exception
 end
 
+if $isTestMode
+  require "config_test.rb"
+end
+
 
 if( $loginCountFileFullPath.nil? )
   $loginCountFileFullPath = File.join($SAVE_DATA_DIR, 'saveData', $loginCountFile)
@@ -196,7 +200,10 @@ class DodontoFServer
     end
     
   end
-  
+  def getRawCGIValue
+    @cgi ||= CGI.new
+    @cgi.params[key].first
+  end
   
   def getRequestData(key)
     @logger.debug(key, "getRequestData key")
@@ -207,8 +214,7 @@ class DodontoFServer
     
     if( value.nil? )
       if( @isWebIf )
-        @cgi ||= CGI.new
-        value = @cgi.params[key].first
+        value = getRawCGIValue
       end
     end
     

--- a/DodontoFServerMySql.rb
+++ b/DodontoFServerMySql.rb
@@ -10,7 +10,9 @@ require 'mysql'
 require 'dodontof/logger'
 require 'dodontof/utils'
 
-$SAVE_DATA_DIR = '.'
+unless $isTestMode
+  $SAVE_DATA_DIR = '.'
+end
 
 #サーバCGIとクライアントFlashのバージョン一致確認用
 $version = "Ver.1.47.24(2016/04/07)"

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -49,6 +49,10 @@ begin
 rescue Exception
 end
 
+if $isTestMode
+  require "config_test.rb"
+end
+
 
 require "FileLock.rb"
 require "saveDirInfoMysql.rb"
@@ -195,7 +199,11 @@ class DodontoFServer
   def initSaveFiles(roomNumber)
     @saveDirInfo.init(roomNumber, $saveDataMaxCount, $SAVE_DATA_DIR)
   end
-  
+
+  def getRawCGIValue
+    @cgi ||= CGI.new
+    @cgi.params[key].first
+  end
   
   def getRequestData(key)
     @logger.debug(key, "getRequestData key")
@@ -206,8 +214,7 @@ class DodontoFServer
     
     if( value.nil? )
       if( @isWebIf )
-        @cgi ||= CGI.new
-        value = @cgi.params[key].first
+        value = getRawCGIValue
       end
     end
     

--- a/test_ruby/config_test.rb
+++ b/test_ruby/config_test.rb
@@ -1,0 +1,10 @@
+#--*-coding:utf-8-*--
+# テスト時用の設定群
+
+$logFileName = "test_log.txt"
+$SAVE_DATA_DIR = ".temp/save"
+$SAVE_DATA_LOCK_FILE_DIR = nil
+$imageUploadDir = ".temp/imageUploadSpace"
+$replayDataUploadDir = ".temp/replayDataUploadSpace"
+$saveDataTempDir = ".temp/saveDataTempSpace"
+$fileUploadDir = ".temp/fileUploadSpace"

--- a/test_ruby/dodontof/test_DodontoFServer.rb
+++ b/test_ruby/dodontof/test_DodontoFServer.rb
@@ -104,6 +104,7 @@ class DodontoFServerTest < Test::Unit::TestCase
   def test_changePlayRoom
     params = {
       'cmd' => 'changePlayRoom',
+      'room' => 1,
       'params' => {
         'playRoomName' => 'TESTROOM_CHANGED',
         'playRoomPassword' => '',

--- a/test_ruby/dodontof/test_DodontoFServer.rb
+++ b/test_ruby/dodontof/test_DodontoFServer.rb
@@ -15,4 +15,181 @@ require 'server_test_impl.rb'
 
 class DodontoFServerTest < Test::Unit::TestCase
   include ServerTestImpl
+
+  class DodontoFServerForGetPlayRoomState < DodontoFServerForTest
+  end
+
+  def create_mock_playroom(name = 'testroom', index = -1)
+    params = {
+      'cmd' => 'createPlayRoom',
+      'params' => {
+        'createPassword' => '',
+        'playRoomName' => name,
+        'playRoomPassword' => '',
+        'chatChannelNames' => '',
+        'canUseExternalImage' => '',
+        'canVisit' => '',
+        'playRoomIndex' => index,
+        'viewStates' => {}
+      }
+    }
+    server = DodontoFServerForTest.new SaveDirInfo.new, params
+    server.getResponse
+  end
+
+  # 'createPlayRoom' => :hasReturn,
+  def test_createPlayRoom
+    expected = "{\"resultText\":\"OK\",\"playRoomIndex\":1}"
+
+    result = create_mock_playroom
+    assert_equal expected, result
+  end
+
+  # 'getPlayRoomStates' => :hasReturn,
+  def test_getPlayRoomState
+    params = {
+      'cmd' => 'getPlayRoomStates',
+      'params' => {
+        'minRoom' => 0,
+        'maxRoom' => 3,
+      }
+    }
+
+    create_mock_playroom('TESTROOM_ALPHA', 1)
+    create_mock_playroom('TESTROOM_BETA', 5)
+    server = DodontoFServerForGetPlayRoomState.new SaveDirInfo.new, params
+    result = server.getResponse
+
+    # 必要なキーは帰ってきてますよね？
+    assert_match /index/, result
+    assert_match /minRoom/, result
+    assert_match /maxRoom/, result
+    assert_match /gameType/, result
+    assert_match /playRoomStates/, result
+    assert_match /playRoomName/, result
+    assert_match /lastUpdateTime/, result
+    assert_match /passwordLockState/, result
+    assert_match /loginUsers/, result
+    assert_match /canVisit/, result
+
+    # TESTROOM_ALPHAはリザルトに入ってますよね？
+    assert_match /TESTROOM_ALPHA/, result
+    # TESTROOM_BETAはリザルトに入って*ません*よね？
+    assert !(/TESTROOM_BETA/ =~ result)
+  end
+
+  # 'checkRoomStatus' => :hasReturn,
+  def test_checkRoomStatus
+    params = {
+      'cmd' => 'checkRoomStatus',
+      'params' => {
+        'roomNumber' => 1
+      }
+    }
+
+    server = DodontoFServerForTest.new SaveDirInfo.new, params
+    result = server.getResponse
+    assert_match /isRoomExist/, result
+    assert_match /roomName/, result
+    assert_match /roomNumber/, result
+    assert_match /chatChannelNames/, result
+    assert_match /canUseExternalImage/, result
+    assert_match /canVisit/, result
+    assert_match /isPasswordLocked/, result
+    assert_match /isMentenanceModeOn/, result
+    assert_match /isWelcomeMessageOn/, result
+  end
+
+  # 'changePlayRoom' => :hasReturn,
+  def test_changePlayRoom
+    params = {
+      'cmd' => 'changePlayRoom',
+      'params' => {
+        'playRoomName' => 'TESTROOM_CHANGED',
+        'playRoomPassword' => '',
+        'chatChannelNames' => '',
+        'canUseExternalImage' => '',
+        'canVisit' => '',
+        'playRoomIndex' => 1,
+        'viewStates' => {}
+      }
+    }
+
+    create_mock_playroom('TESTROOM', 1)
+    server = DodontoFServerForTest.new SaveDirInfo.new, params
+    result = server.getResponse
+    assert_match /resultText/, result
+    assert_match /OK/, result
+
+    state = server.getPlayRoomState(1)
+    assert_equal 'TESTROOM_CHANGED', state['playRoomName']
+  end
+
+  # 'removePlayRoom' => :hasReturn,
+  def test_removePlayRoom
+    params = {
+      'cmd' => 'removePlayRoom',
+      'params' => {
+        'roomNumbers' => [1, 2]
+      }
+    }
+
+    create_mock_playroom('TESTROOM2', 2) # テスト中作って10秒立たないからこれは消せないはず
+
+    server = DodontoFServerForTest.new SaveDirInfo.new, params
+    result = server.getResponse
+    parsed = JsonParser.new.parse(result)
+
+    # ほしいレスポンスキーは帰ってくるのか
+    assert parsed.has_key? 'deletedRoomNumbers'
+    assert parsed.has_key? 'askDeleteRoomNumbers'
+    assert parsed.has_key? 'passwordRoomNumbers'
+    assert parsed.has_key? 'errorMessages'
+
+    # 狙い通りか
+    assert_equal [1], parsed['deletedRoomNumbers']
+    assert_equal [], parsed['askDeleteRoomNumbers']
+    assert_equal [], parsed['passwordRoomNumbers']
+    assert_match /10秒/, parsed['errorMessages'][0]
+
+    state = server.getPlayRoomState(2)
+    assert_match /TESTROOM2/, state['playRoomName']
+  end
+
+  class SaveDirInfoForRemoveOldPlayRoom < SaveDirInfo
+    def getSaveDataLastAccessTimes(fileNames, roomNumberRange)
+      # 強制的に2000年ごろが最終アクセスの古いセーブだったということにする
+      result = super(fileNames, roomNumberRange)
+      result[2] = Time.mktime 2000, 1, 1, 00, 00, 00
+      result
+    end
+  end
+
+  # 'removeOldPlayRoom' => :hasReturn,
+  def test_removeOldPlayRoom
+    params = {
+      'cmd' => 'removeOldPlayRoom',
+      'params' => { }
+    }
+
+    create_mock_playroom('TESTROOM1', 1)
+    create_mock_playroom('TESTROOM2', 2)
+
+    savedirs = SaveDirInfoForRemoveOldPlayRoom.new
+    server = DodontoFServerForTest.new savedirs, params
+    result = server.getResponse
+    parsed = JsonParser.new.parse(result)
+
+    # ほしいレスポンスキーは帰ってくるのか
+    assert parsed.has_key? 'deletedRoomNumbers'
+    assert parsed.has_key? 'askDeleteRoomNumbers'
+    assert parsed.has_key? 'passwordRoomNumbers'
+    assert parsed.has_key? 'errorMessages'
+
+    # 内容は正しいか
+    assert_equal [2], parsed['deletedRoomNumbers']
+    assert_equal [], parsed['askDeleteRoomNumbers']
+    assert_equal [], parsed['passwordRoomNumbers']
+    assert_equal [], parsed['errorMessages']
+  end
 end

--- a/test_ruby/dodontof/test_DodontoFServer.rb
+++ b/test_ruby/dodontof/test_DodontoFServer.rb
@@ -1,0 +1,18 @@
+#--*-coding:utf-8-*--
+$LOAD_PATH.unshift(File.expand_path('..', File.dirname(__FILE__)))
+$LOAD_PATH.unshift(File.expand_path( '../..', File.dirname(__FILE__)))
+
+require 'test_helper'
+
+require 'test/unit'
+
+# テスト用のコンフィグファイルをDodontoFServerに読みこませる
+$isTestMode = true
+require 'DodontoFServer.rb'
+
+TARGET_DODONTF_SERVER_CLASS = DodontoFServer
+require 'server_test_impl.rb'
+
+class DodontoFServerTest < Test::Unit::TestCase
+  include ServerTestImpl
+end

--- a/test_ruby/dodontof/test_DodontoFServerMySql.rb
+++ b/test_ruby/dodontof/test_DodontoFServerMySql.rb
@@ -1,0 +1,18 @@
+#--*-coding:utf-8-*--
+$LOAD_PATH.unshift(File.expand_path('..', File.dirname(__FILE__)))
+$LOAD_PATH.unshift(File.expand_path( '../..', File.dirname(__FILE__)))
+
+require 'test_helper'
+
+require 'test/unit'
+
+# テスト用のコンフィグファイルをDodontoFServerに読みこませる
+$isTestMode = true
+require 'DodontoFServerMySql.rb'
+
+TARGET_DODONTF_SERVER_CLASS = DodontoFServer_MySql
+require 'server_test_impl.rb'
+
+class DodontoFServer_MySqlTest < Test::Unit::TestCase
+  include ServerTestImpl
+end

--- a/test_ruby/dodontof/test_DodontoFServerMySqlKai.rb
+++ b/test_ruby/dodontof/test_DodontoFServerMySqlKai.rb
@@ -1,0 +1,18 @@
+#--*-coding:utf-8-*--
+$LOAD_PATH.unshift(File.expand_path('..', File.dirname(__FILE__)))
+$LOAD_PATH.unshift(File.expand_path( '../..', File.dirname(__FILE__)))
+
+require 'test_helper'
+
+require 'test/unit'
+
+# テスト用のコンフィグファイルをDodontoFServerに読みこませる
+$isTestMode = true
+require 'DodontoFServerMySqlKai.rb'
+
+TARGET_DODONTF_SERVER_CLASS = DodontoFServer
+require 'server_test_impl.rb'
+
+class DodontoFServerMySqlKaiTest < Test::Unit::TestCase
+  include ServerTestImpl
+end

--- a/test_ruby/server_test_impl.rb
+++ b/test_ruby/server_test_impl.rb
@@ -1,0 +1,43 @@
+#--*-coding:utf-8-*--
+
+require 'fileutils'
+
+# 3種類あるサーバ実装を統一的に検査するためのテスト実装モジュール
+# それぞれのサーバ用のテストからincludeして使います
+# テスト中でインスタンス化するのに使うため
+# このrbファイルをrequireする前に
+# TARGET_DODONTF_SERVER_CLASSという定数を、
+# 対象のサーバクラスを代入して初期化してください
+# 例: TARGET_DODONTF_SERVER_CLASS = DodontoFServer
+module ServerTestImpl
+  # テスト用のモックオブジェクト
+  # コンストラクション時にいい加減な物を渡してもエラーを抑止する
+  # モック要件に応じて増やしたり継承したりして使う
+  class DodontoFServerForTest < TARGET_DODONTF_SERVER_CLASS
+    attr_accessor :mock_raw_cgi_value
+    def getRawCGIValue; @mock_raw_cgi_value; end
+  end
+
+  def setup
+    FileUtils.mkdir_p $SAVE_DATA_DIR
+    FileUtils.mkdir_p $imageUploadDir
+    FileUtils.mkdir_p $replayDataUploadDir
+    FileUtils.mkdir_p $saveDataTempDir
+    FileUtils.mkdir_p $fileUploadDir
+    FileUtils.cp_r 'saveData', File.join($SAVE_DATA_DIR, 'saveData')
+  end
+
+  def teardown
+    FileUtils.rm_r '.temp'
+  end
+
+  def test_request_analyze
+    instance = DodontoFServerForTest.new SaveDirInfo.new, {'test' => 'ok'}
+    assert_equal 'ok', instance.getRequestData('test'), 'ok'
+  end
+
+  def test_response
+    instance = DodontoFServerForTest.new SaveDirInfo.new, {'cmd' => ''}
+    assert_match /「.+」の動作環境は正常に起動しています。/, instance.getResponse
+  end
+end


### PR DESCRIPTION
## APIテストを実装しました。

エンドレベルの「あるコマンドをパラメタつけて叩いた時の挙動」をみるタイプのテストを行えるように、
テストフレームワークを構築しました。

また実際にそのテストフレームワークがうまく動くことを確認するために、
room系のコマンドに対する基本的な挙動を見るAPIテストを実装しました。

(ただしこのroom系コマンドのテスト実装はDodontoFServerのみで、
DodontoFServerMySQL, DodontoFServerMySqlKaiはサポートしていません。
今後要改良。テストフレームワークそのものは3つともサポートしています)

## 備考
#15 を受けてやり直したものです～。
今度は取り合えず小さくPRを投げたいのでこれで良ければマージしちゃってください
