### PR TITLE
DiceTable系のコマンド実装を切り出した

### DIFF
--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -3911,21 +3911,6 @@ class DodontoFServer
     return dir
   end
   
-  def makeDir(dir)
-    @logger.debug(dir, "makeDir dir")
-    
-    if( File.exist?(dir) )
-      if( File.directory?(dir) )
-        return
-      end
-      
-      File.delete(dir)
-    end
-    
-    Dir::mkdir(dir)
-    File.chmod(0777, dir)
-  end
-  
   def rmdir(dir)
     SaveDirInfo.removeDir(dir)
   end

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -33,6 +33,7 @@ require 'json/jsonParser'
 
 require 'dodontof/logger'
 require 'dodontof/utils'
+require 'dodontof/dice_adapter'
 
 if( $isFirstCgi )
   require 'cgiPatch_forFirstCgi'
@@ -180,6 +181,8 @@ class DodontoFServer
     @isRecordEmpty = false
 
     @diceBotTablePrefix = 'diceBotTable_'
+    @dice_adapter = DodontoF::DiceAdapter.new(getDiceBotExtraTableDirName, @diceBotTablePrefix)
+
     @fullBackupFileBaseName = "DodontoFFullBackup"
 
     @allSaveDataFileExt = '.tar.gz'
@@ -2425,25 +2428,15 @@ class DodontoFServer
   
   def getGameCommandInfos
     @logger.debug('getGameCommandInfos Begin')
-    
+
     if( @saveDirInfo.getSaveDataDirIndex == -1 )
       @logger.debug('getGameCommandInfos room is -1, so END')
-      
       return []
     end
-    
-    require 'cgiDiceBot.rb'
-    bot = CgiDiceBot.new
-    dir = getDiceBotExtraTableDirName
-    @logger.debug(dir, 'dir')
-    
-    commandInfos = bot.getGameCommandInfos(dir, @diceBotTablePrefix)
-    @logger.debug(commandInfos, "getGameCommandInfos End commandInfos")
-    
-    return commandInfos
+
+    @dice_adapter.getGameCommandInfos
   end
-  
-  
+
   def createDir(playRoomIndex)
     @saveDirInfo.setSaveDataDirIndex(playRoomIndex)
     @saveDirInfo.createDir()
@@ -3023,11 +3016,8 @@ class DodontoFServer
   end
   
   def getDiceTableData()
-    dir = getDiceBotExtraTableDirName
-    tableInfos = getBotTableInfosFromDir(dir)
-    
+    tableInfos = @dice_adapter.getBotTableInfosFromDir
     tableInfos.each{|i| i.delete('fileName') }
-    
     return tableInfos
   end
   
@@ -3343,46 +3333,24 @@ class DodontoFServer
     return ""
   end
   
-  
   def getBotTableInfos()
     @logger.debug("getBotTableInfos Begin")
     result = {
       "resultText"=> "OK",
     }
     
-    dir = getDiceBotExtraTableDirName
-    result["tableInfos"] = getBotTableInfosFromDir(dir)
+    result["tableInfos"] = @dice_adapter.getBotTableInfosFromDir
     
     @logger.debug(result, "result")
     @logger.debug("getBotTableInfos End")
     return result
   end
   
-  def getBotTableInfosFromDir(dir)
-    @logger.debug(dir, 'getBotTableInfosFromDir dir')
-    
-    require 'TableFileData'
-    
-    isLoadCommonTable = false
-    tableFileData = TableFileData.new( isLoadCommonTable )
-    tableFileData.setDir(dir, @diceBotTablePrefix)
-    tableInfos = tableFileData.getAllTableInfo
-    
-    @logger.debug(tableInfos, "getBotTableInfosFromDir tableInfos")
-    tableInfos.sort!{|a, b| a["command"].to_i <=> b["command"].to_i}
-    
-    @logger.debug(tableInfos, 'getBotTableInfosFromDir result tableInfos')
-    
-    return tableInfos
-  end
-  
-  
-  
   def addBotTable()
     result = {}
     
     params = getParamsFromRequestData()
-    result['resultText'] = addBotTableMain(params)
+    result['resultText'] = @dice_adapter.addBotTableMain(params)
     
     if( result['resultText'] != "OK" )
       return result
@@ -3396,31 +3364,11 @@ class DodontoFServer
     return result
   end
 
-  def addBotTableMain(params)
-    @logger.debug("addBotTableMain Begin")
-
-    dir = getDiceBotExtraTableDirName
-    makeDir(dir)
-
-    require 'TableFileData'
-
-    resultText = 'OK'
-    begin
-      creator = TableFileCreator.new(dir, @diceBotTablePrefix, params)
-      creator.execute
-    rescue Exception => e
-      @logger.exception(e)
-      resultText = getLanguageKey( e.to_s )
-    end
-
-    @logger.debug(resultText, "addBotTableMain End resultText")
-
-    return resultText
-  end
-
   def changeBotTable()
+    params = getParamsFromRequestData()
+
     result = {}
-    result['resultText'] = changeBotTableMain()
+    result['resultText'] = @dice_adapter.changeBotTableMain(params)
     
     if( result['resultText'] != "OK" )
       return result
@@ -3430,69 +3378,12 @@ class DodontoFServer
     return result
   end
 
-  def changeBotTableMain()
-    @logger.debug("changeBotTableMain Begin")
-
-    dir = getDiceBotExtraTableDirName
-    params = getParamsFromRequestData()
-
-    require 'TableFileData'
-
-    resultText = 'OK'
-    begin
-      creator = TableFileEditer.new(dir, @diceBotTablePrefix, params)
-      creator.execute 
-    rescue Exception => e
-      @logger.exception(e)
-      resultText = getLanguageKey( e.to_s )
-    end
-
-    @logger.debug(resultText, "changeBotTableMain End resultText")
-
-    return resultText
-  end
-
   def removeBotTable()
-    removeBotTableMain()
+    params = getParamsFromRequestData()
+    @dice_adapter.removeBotTableMain(params)
     return getBotTableInfos()
   end
-  
-  def removeBotTableMain()
-    @logger.debug("removeBotTableMain Begin")
-
-    params = getParamsFromRequestData()
-    command = params["command"]
-
-    dir = getDiceBotExtraTableDirName
-
-    require 'TableFileData'
-
-    isLoadCommonTable = false
-    tableFileData = TableFileData.new( isLoadCommonTable )
-    tableFileData.setDir(dir, @diceBotTablePrefix)
-    tableInfos = tableFileData.getAllTableInfo
-
-    tableInfo = tableInfos.find{|i| i["command"] == command}
-    @logger.debug(tableInfo, "tableInfo")
-    return if( tableInfo.nil? )
-
-    fileName = tableInfo["fileName"]
-    @logger.debug(fileName, "fileName")
-    return if( fileName.nil? )
-
-    @logger.debug("isFile exist?")
-    return unless( File.exist?(fileName) )
-
-    begin
-      File.delete(fileName)
-    rescue Exception => e
-      @logger.exception(e)
-    end
-
-    @logger.debug("removeBotTableMain End")
-  end
-  
-  
+ 
   
   def requestReplayDataList()
     @logger.debug("requestReplayDataList begin")
@@ -4158,7 +4049,7 @@ class DodontoFServer
     
     data.each do |info|
       info['table'] = getDiceBotTableString(info['table'])
-      addBotTableMain(info)
+      @dice_adapter.addBotTableMain(info)
     end
   
   end
@@ -4639,9 +4530,8 @@ class DodontoFServer
   end
   
   def getRollDiceResult( params )
-    
-    rollResult, isSecret, randResults = rollDice(params)
-    
+    rollResult, isSecret, randResults = @dice_adapter.rollDice(params)
+
     secretMessage = ""
     if( isSecret )
       secretMessage = params['message'] + rollResult
@@ -4653,32 +4543,7 @@ class DodontoFServer
     
     return rolledMessage, isSecret, secretMessage
   end
-  
-  
-  def rollDice(params)
-    require 'cgiDiceBot.rb'
-    
-    message = params['message']
-    gameType = params['gameType']
-    isNeedResult = params['isNeedResult']
-    
-    @logger.debug(message, 'rollDice message')
-    @logger.debug(gameType, 'rollDice gameType')
-    
-    bot = CgiDiceBot.new
-    dir = getDiceBotExtraTableDirName
-    
-    result, randResults = bot.roll(message, gameType, dir, @diceBotTablePrefix, isNeedResult)
-    
-    result.gsub!(/＞/, '→')
-    result.sub!(/\r?\n?\Z/m, '')
-    
-    @logger.debug(result, 'rollDice result')
-    @logger.debug(randResults, 'rollDice randResults')
-    
-    return result, bot.isSecret, randResults
-  end
-  
+
   def getDiceBotExtraTableDirName
     getRoomLocalSpaceDirName
   end

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -4728,11 +4728,6 @@ class DodontoFServer
   end
   
   
-  def getLanguageKey(key)
-    '###Language:' + key + '###'
-  end
-  
-  
   def sendChatMessageAll
     @logger.debug("sendChatMessageAll Begin")
     

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -188,6 +188,8 @@ class DodontoFServer_MySqlKai
     @isJsonResult = true
 
     @diceBotTablePrefix = 'diceBotTable_'
+    @dice_adapter = DodontoF::DiceAdapter.new(getDiceBotExtraTableDirName, @diceBotTablePrefix)
+
     @fullBackupFileBaseName = "DodontoFFullBackup"
 
     @allSaveDataFileExt = '.tar.gz'
@@ -2662,22 +2664,14 @@ COMMAND_END
   
   def getGameCommandInfos
     @logger.debug('getGameCommandInfos Begin')
-    
+
     if( @saveDirInfo.getSaveDataDirIndex == -1 )
       @logger.debug('getGameCommandInfos room is -1, so END')
-      
+
       return []
     end
-    
-    require 'cgiDiceBot.rb'
-    bot = CgiDiceBot.new
-    dir = getDiceBotExtraTableDirName
-    @logger.debug(dir, 'dir')
-    
-    commandInfos = bot.getGameCommandInfos(dir, @diceBotTablePrefix)
-    @logger.debug(commandInfos, "getGameCommandInfos End commandInfos")
-    
-    return commandInfos
+
+    return @dice_adapter.getGameCommandInfos
   end
   
   
@@ -3297,8 +3291,7 @@ COMMAND_END
   end
   
   def getDiceTableData()
-    dir = getDiceBotExtraTableDirName
-    tableInfos = getBotTableInfosFromDir(dir)
+    tableInfos = @dice_adapter.getBotTableInfosFromDir
     
     tableInfos.each{|i| i.delete('fileName') }
     
@@ -3606,39 +3599,18 @@ COMMAND_END
       "resultText"=> "OK",
     }
     
-    dir = getDiceBotExtraTableDirName
-    result["tableInfos"] = getBotTableInfosFromDir(dir)
+    result["tableInfos"] = @dice_adapter.getBotTableInfosFromDir
     
     @logger.debug(result, "result")
     @logger.debug("getBotTableInfos End")
     return result
   end
-  
-  def getBotTableInfosFromDir(dir)
-    @logger.debug(dir, 'getBotTableInfosFromDir dir')
-    
-    require 'TableFileData'
-    
-    isLoadCommonTable = false
-    tableFileData = TableFileData.new( isLoadCommonTable )
-    tableFileData.setDir(dir, @diceBotTablePrefix)
-    tableInfos = tableFileData.getAllTableInfo
-    
-    @logger.debug(tableInfos, "getBotTableInfosFromDir tableInfos")
-    tableInfos.sort!{|a, b| a["command"].to_i <=> b["command"].to_i}
-    
-    @logger.debug(tableInfos, 'getBotTableInfosFromDir result tableInfos')
-    
-    return tableInfos
-  end
-  
-  
-  
+ 
   def addBotTable()
     result = {}
     
     params = getParamsFromRequestData()
-    result['resultText'] = addBotTableMain(params)
+    result['resultText'] = @dice_adapter.addBotTableMain(params)
     
     if( result['resultText'] != "OK" )
       return result
@@ -3652,106 +3624,26 @@ COMMAND_END
     return result
   end
   
-  def addBotTableMain(params)
-    @logger.debug("addBotTableMain Begin")
-    
-    dir = getDiceBotExtraTableDirName
-    makeDir(dir)
-    
-    require 'TableFileData'
-    
-    resultText = 'OK'
-    begin
-      creator = TableFileCreator.new(dir, @diceBotTablePrefix, params)
-      creator.execute
-    rescue Exception => e
-      resultText = getLanguageKey( e.to_s )
-    end
-    
-    @logger.debug(resultText, "addBotTableMain End resultText")
-    
-    return resultText
-  end
-  
-  
-  
   def changeBotTable()
+    params = getParamsFromRequestData()
+
     result = {}
-    result['resultText'] = changeBotTableMain()
-    
+    result['resultText'] = @dice_adapter.changeBotTableMain(params)
+
     if( result['resultText'] != "OK" )
       return result
     end
-    
+
     result = getBotTableInfos()
     return result
   end
   
-  def changeBotTableMain()
-    @logger.debug("changeBotTableMain Begin")
-    
-    dir = getDiceBotExtraTableDirName
-    params = getParamsFromRequestData()
-    
-    require 'TableFileData'
-    
-    resultText = 'OK'
-    begin
-      creator = TableFileEditer.new(dir, @diceBotTablePrefix, params)
-      creator.execute 
-    rescue Exception => e
-      resultText = getLanguageKey( e.to_s )
-    end
-    
-    @logger.debug(resultText, "changeBotTableMain End resultText")
-    
-    return resultText
-  end
-  
-  
-  
   def removeBotTable()
-    removeBotTableMain()
+    params = getParamsFromRequestData()
+    @dice_adapter.removeBotTableMain(params)
     return getBotTableInfos()
   end
-  
-  def removeBotTableMain()
-    @logger.debug("removeBotTableMain Begin")
-    
-    params = getParamsFromRequestData()
-    command = params["command"]
-    
-    dir = getDiceBotExtraTableDirName
-    
-    require 'TableFileData'
-    
-    isLoadCommonTable = false
-    tableFileData = TableFileData.new( isLoadCommonTable )
-    tableFileData.setDir(dir, @diceBotTablePrefix)
-    tableInfos = tableFileData.getAllTableInfo
-    
-    tableInfo = tableInfos.find{|i| i["command"] == command}
-    @logger.debug(tableInfo, "tableInfo")
-    return if( tableInfo.nil? )
-    
-    fileName = tableInfo["fileName"]
-    @logger.debug(fileName, "fileName")
-    return if( fileName.nil? )
-    
-    @logger.debug("isFile exist?")
-    return unless( File.exist?(fileName) )
-    
-    begin
-      File.delete(fileName)
-    rescue Exception => e
-      @logger.exception(e)
-    end
-    
-    @logger.debug("removeBotTableMain End")
-  end
-  
-  
-  
+
   def requestReplayDataList()
     @logger.debug("requestReplayDataList begin")
     result = {
@@ -4427,7 +4319,7 @@ COMMAND_END
     
     data.each do |info|
       info['table'] = getDiceBotTableString(info['table'])
-      addBotTableMain(info)
+      @dice_adapter.addBotTableMain(info)
     end
   
   end
@@ -4889,7 +4781,7 @@ COMMAND_END
   
   def getRollDiceResult( params )
     
-    rollResult, isSecret, randResults = rollDice(params)
+    rollResult, isSecret, randResults = @dice_adapter.rollDice(params)
     
     secretMessage = ""
     if( isSecret )
@@ -4901,31 +4793,6 @@ COMMAND_END
     rolledMessage = getRolledMessage(params, isSecret, randResults)
     
     return rolledMessage, isSecret, secretMessage
-  end
-  
-  
-  def rollDice(params)
-    require 'cgiDiceBot.rb'
-    
-    message = params['message']
-    gameType = params['gameType']
-    isNeedResult = params['isNeedResult']
-    
-    @logger.debug(message, 'rollDice message')
-    @logger.debug(gameType, 'rollDice gameType')
-    
-    bot = CgiDiceBot.new
-    dir = getDiceBotExtraTableDirName
-    
-    result, randResults = bot.roll(message, gameType, dir, @diceBotTablePrefix, isNeedResult)
-    
-    result.gsub!(/＞/, '→')
-    result.sub!(/\r?\n?\Z/m, '')
-    
-    @logger.debug(result, 'rollDice result')
-    @logger.debug(randResults, 'rollDice randResults')
-    
-    return result, bot.isSecret, randResults
   end
   
   def getDiceBotExtraTableDirName

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -111,7 +111,7 @@ class Mysql::Stmt
   end
 end
 
-class DodontoFServer
+class DodontoFServer_MySqlKai
   include DodontoF::Utils
 
   def self.getMessagePackFromData(data)
@@ -6983,7 +6983,7 @@ def main(cgiParams)
   logger = DodontoF::Logger.instance
 
   logger.debug("main called")
-  server = DodontoFServer.new(SaveDirInfo.new(), cgiParams)
+  server = DodontoFServer_MySqlKai.new(SaveDirInfo.new(), cgiParams)
   logger.debug("server created")
   printResult(server)
   logger.debug("printResult called")
@@ -7079,7 +7079,7 @@ def getCgiParams()
 
     input = $stdin.read(length)
     logger.debug(input, "getCgiParams input")
-    messagePackedData = DodontoFServer.getMessagePackFromData( input )
+    messagePackedData = DodontoFServer_MySqlKai.getMessagePackFromData( input )
   end
 
   logger.debug(messagePackedData, "messagePackedData")

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -36,6 +36,7 @@ require 'mysql'
 
 require 'dodontof/logger'
 require 'dodontof/utils'
+require 'dodontof/dice_adapter'
 
 if( $isFirstCgi )
   require 'cgiPatch_forFirstCgi'
@@ -4163,21 +4164,6 @@ COMMAND_END
     return dir
   end
   
-  def makeDir(dir)
-    @logger.debug(dir, "makeDir dir")
-    
-    if( File.exist?(dir) )
-      if( File.directory?(dir) )
-        return
-      end
-      
-      File.delete(dir)
-    end
-    
-    Dir::mkdir(dir)
-    File.chmod(0777, dir)
-  end
-  
   def rmdir(dir)
     SaveDirInfo.removeDir(dir)
   end
@@ -4989,13 +4975,7 @@ COMMAND_END
     
     return power
   end
-  
-  
-  def getLanguageKey(key)
-    '###Language:' + key + '###'
-  end
-  
-  
+
   def sendChatMessageAll
     @logger.debug("sendChatMessageAll Begin")
     

--- a/src_bcdice/TableFileData.rb
+++ b/src_bcdice/TableFileData.rb
@@ -397,7 +397,7 @@ class TableFileEditer < TableFileCreator
     originalCommand = @originalCommand
     originalCommand ||= @command
     originalGameType = @originalGameType
-    originalGameType ||= gameType
+    originalGameType ||= @gameType
     
     originalFileName = getTableFileName(originalCommand, originalGameType)
     

--- a/src_ruby/dodontof/dice_adapter.rb
+++ b/src_ruby/dodontof/dice_adapter.rb
@@ -1,0 +1,136 @@
+#--*-coding:utf-8-*--
+module DodontoF
+  # ダイスBOTへのアダプタ
+  class DiceAdapter
+
+    def initialize(dir, prefix)
+      @logger = DodontoF::Logger.instance
+      @dir = dir
+      @diceBotTablePrefix = prefix
+    end
+
+    def rollDice(params)
+      require 'cgiDiceBot.rb'
+
+      message = params['message']
+      gameType = params['gameType']
+      isNeedResult = params['isNeedResult']
+
+      @logger.debug(message, 'rollDice message')
+      @logger.debug(gameType, 'rollDice gameType')
+
+      bot = CgiDiceBot.new
+
+      result, randResults = bot.roll(message, gameType, @dir, @diceBotTablePrefix, isNeedResult)
+
+      result.gsub!(/＞/, '→')
+      result.sub!(/\r?\n?\Z/m, '')
+
+      @logger.debug(result, 'rollDice result')
+      @logger.debug(randResults, 'rollDice randResults')
+
+      return result, bot.isSecret, randResults
+    end
+
+    def getGameCommandInfos
+      require 'cgiDiceBot.rb'
+      bot = CgiDiceBot.new
+      @logger.debug(@dir, 'dir')
+
+      commandInfos = bot.getGameCommandInfos(@dir, @diceBotTablePrefix)
+      @logger.debug(commandInfos, "getGameCommandInfos End commandInfos")
+
+      return commandInfos
+    end
+
+    def getBotTableInfosFromDir
+      @logger.debug(@dir, 'getBotTableInfosFromDir dir')
+
+      require 'TableFileData'
+
+      isLoadCommonTable = false
+      tableFileData = TableFileData.new( isLoadCommonTable )
+      tableFileData.setDir(@dir, @diceBotTablePrefix)
+      tableInfos = tableFileData.getAllTableInfo
+
+      @logger.debug(tableInfos, "getBotTableInfosFromDir tableInfos")
+      tableInfos.sort!{|a, b| a["command"].to_i <=> b["command"].to_i}
+
+      @logger.debug(tableInfos, 'getBotTableInfosFromDir result tableInfos')
+
+      return tableInfos
+    end
+
+    def addBotTableMain(params)
+      @logger.debug("addBotTableMain Begin")
+
+      DodontoF::Utils.makeDir(@dir)
+
+      require 'TableFileData'
+
+      resultText = 'OK'
+      begin
+        creator = TableFileCreator.new(@dir, @diceBotTablePrefix, params)
+        creator.execute
+      rescue Exception => e
+        @logger.exception(e)
+        resultText = getLanguageKey( e.to_s )
+      end
+
+      @logger.debug(resultText, "addBotTableMain End resultText")
+
+      return resultText
+    end
+
+    def changeBotTableMain(params)
+      @logger.debug("changeBotTableMain Begin")
+
+      require 'TableFileData'
+
+      resultText = 'OK'
+      begin
+        creator = TableFileEditer.new(@dir, @diceBotTablePrefix, params)
+        creator.execute
+      rescue Exception => e
+        @logger.exception(e)
+        resultText = getLanguageKey( e.to_s )
+      end
+
+      @logger.debug(resultText, "changeBotTableMain End resultText")
+
+      return resultText
+    end
+
+    def removeBotTableMain(params)
+      @logger.debug("removeBotTableMain Begin")
+
+      command = params["command"]
+
+      require 'TableFileData'
+
+      isLoadCommonTable = false
+      tableFileData = TableFileData.new( isLoadCommonTable )
+      tableFileData.setDir(@dir, @diceBotTablePrefix)
+      tableInfos = tableFileData.getAllTableInfo
+
+      tableInfo = tableInfos.find{|i| i["command"] == command}
+      @logger.debug(tableInfo, "tableInfo")
+      return if( tableInfo.nil? )
+
+      fileName = tableInfo["fileName"]
+      @logger.debug(fileName, "fileName")
+      return if( fileName.nil? )
+
+      @logger.debug("isFile exist?")
+      return unless( File.exist?(fileName) )
+
+      begin
+        File.delete(fileName)
+      rescue Exception => e
+        @logger.exception(e)
+      end
+
+      @logger.debug("removeBotTableMain End")
+    end
+  end
+end

--- a/src_ruby/dodontof/utils.rb
+++ b/src_ruby/dodontof/utils.rb
@@ -43,5 +43,27 @@ module DodontoF
       end
     end
     module_function :getObjectFromJsonString
+
+    # ディレクトリが作成された状態にする
+    # この時なければパーミッションが0777の状態で作る
+    # またディレクトリではなくファイルが存在したならば
+    # そのファイルを削除しながらディレクトリにする
+    # (慣例に従ったが、ensureSaveDirとかそういう名前のほうが適切かも)
+    def makeDir(dir)
+      logger = DodontoF::Logger.instance
+      logger.debug(dir, "makeDir dir")
+
+      if( File.exist?(dir) )
+        if( File.directory?(dir) )
+          return
+        end
+
+        File.delete(dir)
+      end
+
+      Dir::mkdir(dir)
+      File.chmod(0777, dir)
+    end
+    module_function :makeDir
   end
 end

--- a/src_ruby/dodontof/utils.rb
+++ b/src_ruby/dodontof/utils.rb
@@ -65,5 +65,12 @@ module DodontoF
       File.chmod(0777, dir)
     end
     module_function :makeDir
+
+    # 指定されたキー値(文字列)に翻訳のための
+    # 置換キーであることを示すラッピングを施して返します
+    def getLanguageKey(key)
+      '###Language:' + key + '###'
+    end
+    module_function :getLanguageKey
   end
 end

--- a/test_ruby/dodontof/test_DodontoFServer.rb
+++ b/test_ruby/dodontof/test_DodontoFServer.rb
@@ -9,15 +9,16 @@ require 'test/unit'
 # テスト用のコンフィグファイルをDodontoFServerに読みこませる
 $isTestMode = true
 require 'DodontoFServer.rb'
-
-TARGET_DODONTF_SERVER_CLASS = DodontoFServer
 require 'server_test_impl.rb'
 
 class DodontoFServerTest < Test::Unit::TestCase
-  include ServerTestImpl
+  include DodontoFServerTestImpl
 
-  class DodontoFServerForGetPlayRoomState < DodontoFServerForTest
+  def getTargetDodontoFServer
+    DodontoFServer
   end
+
+  # ------------------------ room系コマンドテスト
 
   def create_mock_playroom(name = 'testroom', index = -1)
     params = {
@@ -33,7 +34,7 @@ class DodontoFServerTest < Test::Unit::TestCase
         'viewStates' => {}
       }
     }
-    server = DodontoFServerForTest.new SaveDirInfo.new, params
+    server = getDodontoFServerForTest.new SaveDirInfo.new, params
     server.getResponse
   end
 
@@ -57,7 +58,7 @@ class DodontoFServerTest < Test::Unit::TestCase
 
     create_mock_playroom('TESTROOM_ALPHA', 1)
     create_mock_playroom('TESTROOM_BETA', 5)
-    server = DodontoFServerForGetPlayRoomState.new SaveDirInfo.new, params
+    server = getDodontoFServerForTest.new SaveDirInfo.new, params
     result = server.getResponse
 
     # 必要なキーは帰ってきてますよね？
@@ -87,7 +88,7 @@ class DodontoFServerTest < Test::Unit::TestCase
       }
     }
 
-    server = DodontoFServerForTest.new SaveDirInfo.new, params
+    server = getDodontoFServerForTest.new SaveDirInfo.new, params
     result = server.getResponse
     assert_match /isRoomExist/, result
     assert_match /roomName/, result
@@ -117,7 +118,7 @@ class DodontoFServerTest < Test::Unit::TestCase
     }
 
     create_mock_playroom('TESTROOM', 1)
-    server = DodontoFServerForTest.new SaveDirInfo.new, params
+    server = getDodontoFServerForTest.new SaveDirInfo.new, params
     result = server.getResponse
     assert_match /resultText/, result
     assert_match /OK/, result
@@ -137,7 +138,7 @@ class DodontoFServerTest < Test::Unit::TestCase
 
     create_mock_playroom('TESTROOM2', 2) # テスト中作って10秒立たないからこれは消せないはず
 
-    server = DodontoFServerForTest.new SaveDirInfo.new, params
+    server = getDodontoFServerForTest.new SaveDirInfo.new, params
     result = server.getResponse
     parsed = JsonParser.new.parse(result)
 
@@ -177,7 +178,7 @@ class DodontoFServerTest < Test::Unit::TestCase
     create_mock_playroom('TESTROOM2', 2)
 
     savedirs = SaveDirInfoForRemoveOldPlayRoom.new
-    server = DodontoFServerForTest.new savedirs, params
+    server = getDodontoFServerForTest.new savedirs, params
     result = server.getResponse
     parsed = JsonParser.new.parse(result)
 

--- a/test_ruby/dodontof/test_DodontoFServer.rb
+++ b/test_ruby/dodontof/test_DodontoFServer.rb
@@ -40,10 +40,14 @@ class DodontoFServerTest < Test::Unit::TestCase
 
   # 'createPlayRoom' => :hasReturn,
   def test_createPlayRoom
-    expected = "{\"resultText\":\"OK\",\"playRoomIndex\":1}"
-
     result = create_mock_playroom
-    assert_equal expected, result
+    parsed = JsonParser.new.parse(result)
+
+    assert parsed.has_key? 'resultText'
+    assert parsed.has_key? 'playRoomIndex'
+
+    assert_equal 'OK', parsed['resultText']
+    assert_equal 1, parsed['playRoomIndex']
   end
 
   # 'getPlayRoomStates' => :hasReturn,
@@ -193,5 +197,152 @@ class DodontoFServerTest < Test::Unit::TestCase
     assert_equal [], parsed['askDeleteRoomNumbers']
     assert_equal [], parsed['passwordRoomNumbers']
     assert_equal [], parsed['errorMessages']
+  end
+
+  # ------------------------ bot系コマンドテスト
+
+ def test_getDiceBotInfos
+    params = {
+      'cmd' => 'getDiceBotInfos',
+      'params' => { }
+    }
+
+    server = getDodontoFServerForTest.new SaveDirInfo.new, params
+    result = server.getResponse
+    parsed = JsonParser.new.parse(result)
+    assert 1 <= parsed.size
+    parsed.each do |item|
+      assert item.has_key? 'name'
+      assert item.has_key? 'gameType'
+      assert item.has_key? 'prefixs'
+      assert item.has_key? 'info'
+    end
+ end
+
+  def test_getBotTableInfos
+    params = {
+      'cmd' => 'getBotTableInfos',
+      'params' => { }
+    }
+
+    server = getDodontoFServerForTest.new SaveDirInfo.new, params
+    result = server.getResponse
+    parsed = JsonParser.new.parse(result)
+
+    assert parsed.has_key? 'resultText'
+    assert parsed.has_key? 'tableInfos'
+  end
+
+  def create_mock_bot_table(title)
+    params = {
+      'cmd' => 'addBotTable',
+      'params' => {
+        'gameType' => 'DiceBot',
+        'command' => '1d6',
+        'dice' => '',
+        'title' => title,
+        'table' => []
+      }
+    }
+    server = getDodontoFServerForTest.new SaveDirInfo.new, params
+    server.getResponse
+  end
+
+  def test_addBotTable
+    result = create_mock_bot_table('TEST')
+    parsed = JsonParser.new.parse(result)
+
+    assert parsed.has_key? 'resultText'
+    assert parsed.has_key? 'tableInfos'
+
+    item = parsed['tableInfos'][0]
+
+    assert item.has_key? 'fileName'
+    assert item.has_key? 'gameType'
+    assert item.has_key? 'command'
+    assert item.has_key? 'dice'
+    assert item.has_key? 'title'
+    assert item.has_key? 'table'
+  end
+
+  def test_changeBotTable
+    params = {
+      'cmd' => 'changeBotTable',
+      'params' => {
+        # 変えるときは元の値をここで指定できる
+        # 変えない時も指定しても動く
+        'originalGameType' => 'DiceBot',
+        'originalCommand' => '1d6',
+
+        'gameType' => 'DiceBot',
+        'command' => '1d6',
+        # dice, titleは指定しなくても動いちゃうので
+        # この辺はもしかしたらエラーチェックを入れたほうがいいのかもしれない
+        'dice' => 'DICE_TEST',
+        'title' => 'TEST_CHANGED',
+        # tableは指定しないとnilで落ちる。
+        # dice, titleと非対称な感じなのでどちらかに合わせたいところだが...。
+        'table' => [
+          '1:TABLETEST_1',
+          '2:TABLETEST_2'
+        ],
+      }
+    }
+
+    create_mock_bot_table('TEST')
+
+    server = getDodontoFServerForTest.new savedirs = SaveDirInfo.new, params
+    result = server.getResponse
+    parsed = JsonParser.new.parse(result)
+
+    assert parsed.has_key? 'resultText'
+    assert parsed.has_key? 'tableInfos'
+
+    item = parsed['tableInfos'][0]
+    assert item.has_key? 'fileName'
+    assert item.has_key? 'gameType'
+    assert item.has_key? 'command'
+    assert item.has_key? 'dice'
+    assert item.has_key? 'title'
+    assert item.has_key? 'table'
+
+    # prefixにマッチする名前になってる
+    assert_match /diceBotTable_/, item['fileName']
+    # gameTypeにマッチする名前になってる
+    assert_match /DiceBot/, item['fileName']
+    # commandにマッチする名前になってる
+    assert_match /1d6/, item['fileName']
+
+    assert_equal '1d6', item['command']
+    assert_equal 'DICE_TEST', item['dice']
+    assert_equal 'TEST_CHANGED', item['title']
+
+    table = item['table']
+    assert_equal 2, table.size
+    assert_equal 1, table[0][0]
+    assert_equal 2, table[1][0]
+    assert_match /TABLETEST_/, table[0][1]
+    assert_match /TABLETEST_/, table[1][1]
+  end
+
+  def test_removeBotTable
+    params = {
+      'cmd' => 'removeBotTable',
+      'params' => {
+        'gameType' => 'DiceBot',
+        'command' => '1d6',
+      }
+    }
+
+    create_mock_bot_table('TEST')
+
+    server = getDodontoFServerForTest.new SaveDirInfo.new, params
+    result = server.getResponse
+    parsed = JsonParser.new.parse(result)
+
+    assert parsed.has_key? 'resultText'
+    assert parsed.has_key? 'tableInfos'
+    # 削除されて0件が返ってくるはず
+    assert_equal 0, parsed['tableInfos'].size
   end
 end

--- a/test_ruby/dodontof/test_DodontoFServerMySql.rb
+++ b/test_ruby/dodontof/test_DodontoFServerMySql.rb
@@ -9,10 +9,11 @@ require 'test/unit'
 # テスト用のコンフィグファイルをDodontoFServerに読みこませる
 $isTestMode = true
 require 'DodontoFServerMySql.rb'
-
-TARGET_DODONTF_SERVER_CLASS = DodontoFServer_MySql
 require 'server_test_impl.rb'
 
 class DodontoFServer_MySqlTest < Test::Unit::TestCase
-  include ServerTestImpl
+  include DodontoFServerTestImpl
+  def getTargetDodontoFServer
+    DodontoFServer_MySql
+  end
 end

--- a/test_ruby/dodontof/test_DodontoFServerMySqlKai.rb
+++ b/test_ruby/dodontof/test_DodontoFServerMySqlKai.rb
@@ -9,10 +9,11 @@ require 'test/unit'
 # テスト用のコンフィグファイルをDodontoFServerに読みこませる
 $isTestMode = true
 require 'DodontoFServerMySqlKai.rb'
-
-TARGET_DODONTF_SERVER_CLASS = DodontoFServer
 require 'server_test_impl.rb'
 
 class DodontoFServerMySqlKaiTest < Test::Unit::TestCase
-  include ServerTestImpl
+  include DodontoFServerTestImpl
+  def getTargetDodontoFServer
+    DodontoFServer_MySqlKai
+  end
 end

--- a/test_ruby/dodontof/test_utils.rb
+++ b/test_ruby/dodontof/test_utils.rb
@@ -44,5 +44,14 @@ module DodontoF
       assert File.exists? './.temp/makeDirTest'
       assert File.directory? './.temp/makeDirTest'
     end
+
+    # getLanguageKeyはキー値に対して何らかのラッピングを施す
+    # (ラップキーが適切についているか？というのを検査するのは
+    # ただのChangeDetectorになるので避けた)
+    def test_getLanguageKey
+      # LanguageKeyはキー値を何らかの形でラップしたものであるはずだから
+      # 少なくとも指定したキーとマッチする部分列があるはずだ
+      assert_match /test/, Utils.getLanguageKey('test')
+    end
   end
 end

--- a/test_ruby/dodontof/test_utils.rb
+++ b/test_ruby/dodontof/test_utils.rb
@@ -8,6 +8,8 @@ require 'test/unit'
 
 require 'dodontof/utils'
 
+require 'fileutils'
+
 module DodontoF
   # ユーティリティメソッドのテスト
   class UtilsTest < Test::Unit::TestCase
@@ -29,6 +31,18 @@ module DodontoF
       assert_equal({ 'a' => 1 },
                    Utils.getObjectFromJsonString('{"a":1}'),
                    'オブジェクトを表す JSON 文字列を渡した場合')
+    end
+
+    # makeDir は 適当なディレクトリをその場に「存在する状態」にする
+    # この時他にファイルがあれば上書きする
+    def test_makeDir
+      # そういうディレクトリを構成しておく
+      FileUtils.mkdir_p './.temp'
+      open('./.temp/makeDirTest', 'w') { |f| f.puts 'test' }
+
+      Utils.makeDir('.temp/makeDirTest')
+      assert File.exists? './.temp/makeDirTest'
+      assert File.directory? './.temp/makeDirTest'
     end
   end
 end

--- a/test_ruby/server_test_impl.rb
+++ b/test_ruby/server_test_impl.rb
@@ -3,19 +3,27 @@
 require 'fileutils'
 
 # 3種類あるサーバ実装を統一的に検査するためのテスト実装モジュール
-# それぞれのサーバ用のテストからincludeして使います
-# テスト中でインスタンス化するのに使うため
-# このrbファイルをrequireする前に
-# TARGET_DODONTF_SERVER_CLASSという定数を、
-# 対象のサーバクラスを代入して初期化してください
-# 例: TARGET_DODONTF_SERVER_CLASS = DodontoFServer
-module ServerTestImpl
+# それぞれのサーバ用のテストケースでincludeして使います。
+# 共通するテストはこのクラスの中で書いてしまってください。
+# またどのサーバ実装を対象にするのかは
+# getTargetDodontoFServerメソッドをオーバライドして
+# クラス定数を返却しておくことで、こちらに伝えるようにしてください
+# (内部的にDodontoFServer類をテストに乗せるためのモックオブジェクトを生成します)
+module DodontoFServerTestImpl
+  # テスト対象にするDodontoFServer
+  # 利用者コードでinclude後にオーバライドしてください
+  def getTargetDodontoFServer
+    fail NotImplementedError, 'ServerTestimpl need override TargetDodontoFServer()'
+  end
+
   # テスト用のモックオブジェクト
   # コンストラクション時にいい加減な物を渡してもエラーを抑止する
   # モック要件に応じて増やしたり継承したりして使う
-  class DodontoFServerForTest < TARGET_DODONTF_SERVER_CLASS
-    attr_accessor :mock_raw_cgi_value
-    def getRawCGIValue; @mock_raw_cgi_value; end
+  def getDodontoFServerForTest
+    @dodontof_server_for_Test ||= Class.new(getTargetDodontoFServer) do
+      attr_accessor :mock_raw_cgi_value
+      def getRawCGIValue; @mock_raw_cgi_value; end
+    end
   end
 
   def setup
@@ -32,12 +40,12 @@ module ServerTestImpl
   end
 
   def test_request_analyze
-    instance = DodontoFServerForTest.new SaveDirInfo.new, {'test' => 'ok'}
+    instance = getDodontoFServerForTest.new SaveDirInfo.new, {'test' => 'ok'}
     assert_equal 'ok', instance.getRequestData('test'), 'ok'
   end
 
   def test_response
-    instance = DodontoFServerForTest.new SaveDirInfo.new, {'cmd' => ''}
+    instance = getDodontoFServerForTest.new SaveDirInfo.new, {'cmd' => ''}
     assert_match /「.+」の動作環境は正常に起動しています。/, instance.getResponse
   end
 end


### PR DESCRIPTION
# 注意点

#22 を先にお願いたしますー。


# このPRなに？

dicebotの呼び出し部分の実装が `DodontoFServer` と
`DodontoFServerMySqlKai` の両方に登場して、
まったく同じ処理だったので切り出して共通化しました。
あとついでに #17 の方法を使ってテストを揃えました。(実はこっちがメインかもしれない)

このまとめる上で、対象ディレクトリの引っ張り出しタイミングは、
`DodontoFServer` の `initialize()` の所定のタイミングでよいことも分かったので
これも引き出しのタイミングを一元化しました。

またこの作業の過程で `makeDir`, `getLanguage` を `DodontoF::Utils` に切り出しました。
さらにテストをして発見した `TableFileData` バグ（originalGameTypeの再代入処理に @gameType ではなく gameType という存在しない変数・関数を使ってしまっている) を訂正しました
(該当の行: https://github.com/torgtaitai/DodontoF/commit/26400538b38418adb0742465a83f78928f71ca2b#diff-2a4f4683f6639595eb953a5d8e5461b4L400 )