### PR TITLE
使われることのないSampleModeを削除

### DIFF
--- a/src_ruby/saveDirInfo.rb
+++ b/src_ruby/saveDirInfo.rb
@@ -30,13 +30,8 @@ class SaveDirInfo
     @saveDataDirIndex = nil
     @subDir = subDir
     @saveDataMaxCount = saveDataMaxCount
-    @sampleMode = false
 
     @logger = DodontoF::Logger.instance
-  end
-  
-  def setSampleMode
-    @sampleMode = true
   end
   
   def getMaxCount
@@ -131,10 +126,8 @@ class SaveDirInfo
     
     @logger.debug(saveDataDirIndex.inspect, "saveDataDirIndex")
     
-    unless( @sampleMode )
-      if( saveDataDirIndex > @saveDataMaxCount )
-        raise "saveDataDirIndex:#{saveDataDirIndex} is over Limit:(#{@saveDataMaxCount}"
-      end
+    if( saveDataDirIndex > @saveDataMaxCount )
+      raise "saveDataDirIndex:#{saveDataDirIndex} is over Limit:(#{@saveDataMaxCount}"
     end
     
     @logger.debug(saveDataDirIndex, "saveDataDirIndex")

--- a/src_ruby/saveDirInfoMysql.rb
+++ b/src_ruby/saveDirInfoMysql.rb
@@ -30,13 +30,8 @@ class SaveDirInfo
     @saveDataDirIndex = nil
     @subDir = subDir
     @saveDataMaxCount = saveDataMaxCount
-    @sampleMode = false
 
     @logger = DodontoF::Logger.instance
-  end
-  
-  def setSampleMode
-    @sampleMode = true
   end
   
   def getMaxCount
@@ -127,10 +122,8 @@ class SaveDirInfo
     
     @logger.debug(saveDataDirIndex.inspect, "saveDataDirIndex")
     
-    unless( @sampleMode )
-      if( saveDataDirIndex > @saveDataMaxCount )
-        raise "saveDataDirIndex:#{saveDataDirIndex} is over Limit:(#{@saveDataMaxCount}"
-      end
+    if( saveDataDirIndex > @saveDataMaxCount )
+      raise "saveDataDirIndex:#{saveDataDirIndex} is over Limit:(#{@saveDataMaxCount}"
     end
     
     @logger.debug(saveDataDirIndex, "saveDataDirIndex")


### PR DESCRIPTION
# 注意点

#18 の次にお願いします。(#18のブランチからブランチを切っているので、#18の内容を含んでいます。)

# なにこれ？

`SaveDataDir`, `SaveDataDirMySql` は、どちらも `@sampleMode` というモードを内部に持っています。
しかしこの値はコンストラクト時には初期化されないため `nil`,
その後の `init()` では `false` に設定されています。

このモードパラメタに代入が起きるのは `setSampleMode()` の陽な呼び出しによるものだけで、
このときは `true` になるのですが、
リポジトリ内のすべての箇所で `setSampleMode()` は呼び出しがありません。
したがって `@sampleMode` は常に `false` と見做せます。

さて、利用されない状態が存在すると、コードの状況が分かりづらくなるため、このモードを削除しました。