### PR TITLE
rmdirをUtilsに移動した

### DIFF
--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -3802,10 +3802,6 @@ class DodontoFServer
     return dir
   end
   
-  def rmdir(dir)
-    SaveDirInfo.removeDir(dir)
-  end
-  
   def loadAllSaveDataDefaultInfo(dir)
     loadAllSaveDataDefaultSaveData(dir)
     chatPaletteSaveData = loadAllSaveDataDefaultChatPallete(dir)

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -4055,11 +4055,7 @@ COMMAND_END
     dir = File.join($imageUploadDir, "room_#{roomNo}")
     return dir
   end
-  
-  def rmdir(dir)
-    SaveDirInfo.removeDir(dir)
-  end
-  
+
   def loadAllSaveDataDefaultInfo(dir)
     loadAllSaveDataDefaultSaveData(dir)
     chatPaletteSaveData = loadAllSaveDataDefaultChatPallete(dir)

--- a/src_ruby/dodontof/utils.rb
+++ b/src_ruby/dodontof/utils.rb
@@ -2,8 +2,10 @@
 
 require 'cgi'
 require 'json/jsonParser'
+require 'fileutils'
 
 require 'dodontof/logger'
+
 
 module DodontoF
   # ユーティリティメソッドを格納するモジュール
@@ -65,6 +67,28 @@ module DodontoF
       File.chmod(0777, dir)
     end
     module_function :makeDir
+
+    # ディレクトリを削除します
+    def rmdir(dirName)
+      return unless( FileTest.directory?(dirName) )
+
+      # force = true
+      # FileUtils.remove_entry_secure(dirName, force)
+      # 上記のメソッドは一部レンタルサーバ(さくらインターネット等）で禁止されているので、
+      # この下の方法で対応しています。
+
+      logger = DodontoF::Logger.instance
+
+      files = Dir.glob( File.join(dirName, "*") )
+
+      logger.debug(files, "rmdir files")
+      files.each do |fileName|
+        File.delete(fileName.untaint)
+      end
+
+      Dir.delete(dirName)
+    end
+    module_function :rmdir
 
     # 指定されたキー値(文字列)に翻訳のための
     # 置換キーであることを示すラッピングを施して返します

--- a/src_ruby/saveDirInfo.rb
+++ b/src_ruby/saveDirInfo.rb
@@ -5,26 +5,6 @@ require 'fileutils'
 require 'dodontof/logger'
 
 class SaveDirInfo
-  def self.removeDir(dirName)
-    return unless( FileTest.directory?(dirName) )
-
-    # force = true
-    # FileUtils.remove_entry_secure(dirName, force)
-    # 上記のメソッドは一部レンタルサーバ(さくらインターネット等）で禁止されているので、
-    # この下の方法で対応しています。
-
-    logger = DodontoF::Logger.instance
-
-    files = Dir.glob( File.join(dirName, "*") )
-
-    logger.debug(files, "removeDir files")
-    files.each do |fileName|
-      File.delete(fileName.untaint)
-    end
-
-    Dir.delete(dirName)
-  end
-  
   def init(saveDataDirIndexObject, saveDataMaxCount = 0, subDir = '.')
     @saveDataDirIndexObject = saveDataDirIndexObject
     @saveDataDirIndex = nil
@@ -203,7 +183,7 @@ class SaveDirInfo
   
   def removeSaveDir(saveDataDirIndex)
     dirName = getDirNameByIndex(saveDataDirIndex)
-    self.class.removeDir(dirName)
+    DodontoF::Utils.rmdir(dirName)
   end
   
   def getTrueSaveFileName(saveFileName)

--- a/src_ruby/saveDirInfoMysql.rb
+++ b/src_ruby/saveDirInfoMysql.rb
@@ -5,26 +5,6 @@ require 'fileutils'
 require 'dodontof/logger'
 
 class SaveDirInfo
-  def self.removeDir(dirName)
-    return unless( FileTest.directory?(dirName) )
-
-    # force = true
-    # FileUtils.remove_entry_secure(dirName, force)
-    # 上記のメソッドは一部レンタルサーバ(さくらインターネット等）で禁止されているので、
-    # この下の方法で対応しています。
-
-    logger = DodontoF::Logger.instance
-
-    files = Dir.glob( File.join(dirName, "*") )
-
-    logger.debug(files, "removeDir files")
-    files.each do |fileName|
-      File.delete(fileName.untaint)
-    end
-
-    Dir.delete(dirName)
-  end
-  
   def init(saveDataDirIndexObject, saveDataMaxCount = 0, subDir = '.')
     @saveDataDirIndexObject = saveDataDirIndexObject
     @saveDataDirIndex = nil
@@ -172,7 +152,7 @@ class SaveDirInfo
   
   def removeSaveDir(saveDataDirIndex)
     dirName = getDirNameByIndex(saveDataDirIndex)
-    self.class.removeDir(dirName)
+    DodontoF::Utils.rmdir(dirName)
   end
   
   def getTrueSaveFileName(saveFileName)

--- a/test_ruby/dodontof/test_utils.rb
+++ b/test_ruby/dodontof/test_utils.rb
@@ -45,6 +45,17 @@ module DodontoF
       assert File.directory? './.temp/makeDirTest'
     end
 
+    # rmdir は指定したディレクトリを削除する
+    def test_rmdir
+      # そういうディレクトリを構成しておく
+      FileUtils.mkdir_p './.temp/test'
+      assert File.exists? './.temp/test'
+
+      Utils.rmdir('.temp/test')
+      assert File.exists? './.temp/'
+      assert !(File.exists? './.temp/test')
+    end
+
     # getLanguageKeyはキー値に対して何らかのラッピングを施す
     # (ラップキーが適切についているか？というのを検査するのは
     # ただのChangeDetectorになるので避けた)


### PR DESCRIPTION
# 注意

#19  を先にお願いします

# なにこれ

`makeDir` を前にUtilsに切り出したのですが、それと同じように `rmdir` を切り出しました。
`saveDirInfo` 以外の用途でも使える(使っている)汎用のメソッドであるため
このメソッドを `saveDirInfo` に持たせず、`Utils` に置きました