### PR TITLE
rake上のTestRunnerではコンテキスト共有されてしまうので分離動作させた

### DIFF
--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -111,7 +111,7 @@ class Mysql::Stmt
   end
 end
 
-class DodontoFServer
+class DodontoFServer_MySqlKai
   include DodontoF::Utils
 
   def self.getMessagePackFromData(data)
@@ -6983,7 +6983,7 @@ def main(cgiParams)
   logger = DodontoF::Logger.instance
 
   logger.debug("main called")
-  server = DodontoFServer.new(SaveDirInfo.new(), cgiParams)
+  server = DodontoFServer_MySqlKai.new(SaveDirInfo.new(), cgiParams)
   logger.debug("server created")
   printResult(server)
   logger.debug("printResult called")
@@ -7079,7 +7079,7 @@ def getCgiParams()
 
     input = $stdin.read(length)
     logger.debug(input, "getCgiParams input")
-    messagePackedData = DodontoFServer.getMessagePackFromData( input )
+    messagePackedData = DodontoFServer_MySqlKai.getMessagePackFromData( input )
   end
 
   logger.debug(messagePackedData, "messagePackedData")

--- a/test_ruby/dodontof/test_DodontoFServer.rb
+++ b/test_ruby/dodontof/test_DodontoFServer.rb
@@ -9,15 +9,16 @@ require 'test/unit'
 # テスト用のコンフィグファイルをDodontoFServerに読みこませる
 $isTestMode = true
 require 'DodontoFServer.rb'
-
-TARGET_DODONTF_SERVER_CLASS = DodontoFServer
 require 'server_test_impl.rb'
 
 class DodontoFServerTest < Test::Unit::TestCase
-  include ServerTestImpl
+  include DodontoFServerTestImpl
 
-  class DodontoFServerForGetPlayRoomState < DodontoFServerForTest
+  def getTargetDodontoFServer
+    DodontoFServer
   end
+
+  # ------------------------ room系コマンドテスト
 
   def create_mock_playroom(name = 'testroom', index = -1)
     params = {
@@ -33,7 +34,7 @@ class DodontoFServerTest < Test::Unit::TestCase
         'viewStates' => {}
       }
     }
-    server = DodontoFServerForTest.new SaveDirInfo.new, params
+    server = getDodontoFServerForTest.new SaveDirInfo.new, params
     server.getResponse
   end
 
@@ -57,7 +58,7 @@ class DodontoFServerTest < Test::Unit::TestCase
 
     create_mock_playroom('TESTROOM_ALPHA', 1)
     create_mock_playroom('TESTROOM_BETA', 5)
-    server = DodontoFServerForGetPlayRoomState.new SaveDirInfo.new, params
+    server = getDodontoFServerForTest.new SaveDirInfo.new, params
     result = server.getResponse
 
     # 必要なキーは帰ってきてますよね？
@@ -87,7 +88,7 @@ class DodontoFServerTest < Test::Unit::TestCase
       }
     }
 
-    server = DodontoFServerForTest.new SaveDirInfo.new, params
+    server = getDodontoFServerForTest.new SaveDirInfo.new, params
     result = server.getResponse
     assert_match /isRoomExist/, result
     assert_match /roomName/, result
@@ -117,7 +118,7 @@ class DodontoFServerTest < Test::Unit::TestCase
     }
 
     create_mock_playroom('TESTROOM', 1)
-    server = DodontoFServerForTest.new SaveDirInfo.new, params
+    server = getDodontoFServerForTest.new SaveDirInfo.new, params
     result = server.getResponse
     assert_match /resultText/, result
     assert_match /OK/, result
@@ -137,7 +138,7 @@ class DodontoFServerTest < Test::Unit::TestCase
 
     create_mock_playroom('TESTROOM2', 2) # テスト中作って10秒立たないからこれは消せないはず
 
-    server = DodontoFServerForTest.new SaveDirInfo.new, params
+    server = getDodontoFServerForTest.new SaveDirInfo.new, params
     result = server.getResponse
     parsed = JsonParser.new.parse(result)
 
@@ -177,7 +178,7 @@ class DodontoFServerTest < Test::Unit::TestCase
     create_mock_playroom('TESTROOM2', 2)
 
     savedirs = SaveDirInfoForRemoveOldPlayRoom.new
-    server = DodontoFServerForTest.new savedirs, params
+    server = getDodontoFServerForTest.new savedirs, params
     result = server.getResponse
     parsed = JsonParser.new.parse(result)
 

--- a/test_ruby/dodontof/test_DodontoFServerMySql.rb
+++ b/test_ruby/dodontof/test_DodontoFServerMySql.rb
@@ -9,10 +9,11 @@ require 'test/unit'
 # テスト用のコンフィグファイルをDodontoFServerに読みこませる
 $isTestMode = true
 require 'DodontoFServerMySql.rb'
-
-TARGET_DODONTF_SERVER_CLASS = DodontoFServer_MySql
 require 'server_test_impl.rb'
 
 class DodontoFServer_MySqlTest < Test::Unit::TestCase
-  include ServerTestImpl
+  include DodontoFServerTestImpl
+  def getTargetDodontoFServer
+    DodontoFServer_MySql
+  end
 end

--- a/test_ruby/dodontof/test_DodontoFServerMySqlKai.rb
+++ b/test_ruby/dodontof/test_DodontoFServerMySqlKai.rb
@@ -9,10 +9,11 @@ require 'test/unit'
 # テスト用のコンフィグファイルをDodontoFServerに読みこませる
 $isTestMode = true
 require 'DodontoFServerMySqlKai.rb'
-
-TARGET_DODONTF_SERVER_CLASS = DodontoFServer
 require 'server_test_impl.rb'
 
 class DodontoFServerMySqlKaiTest < Test::Unit::TestCase
-  include ServerTestImpl
+  include DodontoFServerTestImpl
+  def getTargetDodontoFServer
+    DodontoFServer_MySqlKai
+  end
 end

--- a/test_ruby/server_test_impl.rb
+++ b/test_ruby/server_test_impl.rb
@@ -3,19 +3,27 @@
 require 'fileutils'
 
 # 3種類あるサーバ実装を統一的に検査するためのテスト実装モジュール
-# それぞれのサーバ用のテストからincludeして使います
-# テスト中でインスタンス化するのに使うため
-# このrbファイルをrequireする前に
-# TARGET_DODONTF_SERVER_CLASSという定数を、
-# 対象のサーバクラスを代入して初期化してください
-# 例: TARGET_DODONTF_SERVER_CLASS = DodontoFServer
-module ServerTestImpl
+# それぞれのサーバ用のテストケースでincludeして使います。
+# 共通するテストはこのクラスの中で書いてしまってください。
+# またどのサーバ実装を対象にするのかは
+# getTargetDodontoFServerメソッドをオーバライドして
+# クラス定数を返却しておくことで、こちらに伝えるようにしてください
+# (内部的にDodontoFServer類をテストに乗せるためのモックオブジェクトを生成します)
+module DodontoFServerTestImpl
+  # テスト対象にするDodontoFServer
+  # 利用者コードでinclude後にオーバライドしてください
+  def getTargetDodontoFServer
+    fail NotImplementedError, 'ServerTestimpl need override TargetDodontoFServer()'
+  end
+
   # テスト用のモックオブジェクト
   # コンストラクション時にいい加減な物を渡してもエラーを抑止する
   # モック要件に応じて増やしたり継承したりして使う
-  class DodontoFServerForTest < TARGET_DODONTF_SERVER_CLASS
-    attr_accessor :mock_raw_cgi_value
-    def getRawCGIValue; @mock_raw_cgi_value; end
+  def getDodontoFServerForTest
+    @dodontof_server_for_Test ||= Class.new(getTargetDodontoFServer) do
+      attr_accessor :mock_raw_cgi_value
+      def getRawCGIValue; @mock_raw_cgi_value; end
+    end
   end
 
   def setup
@@ -32,12 +40,12 @@ module ServerTestImpl
   end
 
   def test_request_analyze
-    instance = DodontoFServerForTest.new SaveDirInfo.new, {'test' => 'ok'}
+    instance = getDodontoFServerForTest.new SaveDirInfo.new, {'test' => 'ok'}
     assert_equal 'ok', instance.getRequestData('test'), 'ok'
   end
 
   def test_response
-    instance = DodontoFServerForTest.new SaveDirInfo.new, {'cmd' => ''}
+    instance = getDodontoFServerForTest.new SaveDirInfo.new, {'cmd' => ''}
     assert_match /「.+」の動作環境は正常に起動しています。/, instance.getResponse
   end
 end


### PR DESCRIPTION
Twitterの件のテストの修正です。
DodontoFServerMySqlKai.rb の `DodontoFServer` を
`DodontoFServerMySqlKai` にリネームさせていただき、
メソッド上書きにならないようにいくらかの修正を入れてみました。

(他よりも先にこれを入れていただいた方がいいと思います)