### PR TITLE
PlayRoomの概念をクラスとして抽出した

### DIFF
--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2697,11 +2697,6 @@ class DodontoFServer
     DodontoF::PlayRoom.new(self, @saveDirInfo).check(params)
   end
   
-  def isMentenanceMode(adminPassword)
-    return false if( $mentenanceModePassword.nil? )
-    return ( adminPassword == $mentenanceModePassword )
-  end
-  
   def loginPassword()
     loginData = getParamsFromRequestData()
     @logger.debug(loginData, 'loginData')

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -1873,13 +1873,6 @@ class DodontoFServer
     saveData[uniqueId] = userInfo
   end
   
-  
-  def getPlayRoomName(saveData, index)
-    playRoomName = saveData['playRoomName']
-    playRoomName ||= "プレイルームNo.#{index}"
-    return playRoomName
-  end
-  
   def getLoginUserCountList( roomNumberRange )
     loginUserCountList = {}
     roomNumberRange.each{|i| loginUserCountList[i] = 0 }

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -34,6 +34,7 @@ require 'json/jsonParser'
 require 'dodontof/logger'
 require 'dodontof/utils'
 require 'dodontof/dice_adapter'
+require 'dodontof/play_room'
 
 if( $isFirstCgi )
   require 'cgiPatch_forFirstCgi'
@@ -2443,76 +2444,7 @@ class DodontoFServer
   end
   
   def createPlayRoom()
-    @logger.debug('createPlayRoom begin')
-    
-    resultText = "OK"
-    playRoomIndex = -1
-    begin
-      params = getParamsFromRequestData()
-      @logger.debug(params, "params")
-      
-      checkCreatePlayRoomPassword(params['createPassword'])
-      
-      playRoomName = params['playRoomName']
-      playRoomPassword = params['playRoomPassword']
-      chatChannelNames = params['chatChannelNames']
-      canUseExternalImage = params['canUseExternalImage']
-      
-      canVisit = params['canVisit']
-      playRoomIndex = params['playRoomIndex']
-      
-      if( playRoomIndex == -1 )
-        playRoomIndex = findEmptyRoomNumber()
-        raise "noEmptyPlayRoom" if(playRoomIndex == -1)
-        
-        @logger.debug(playRoomIndex, "findEmptyRoomNumber playRoomIndex")
-      end
-      
-      @logger.debug(playRoomName, 'playRoomName')
-      @logger.debug('playRoomPassword is get')
-      @logger.debug(playRoomIndex, 'playRoomIndex')
-      
-      initSaveFiles(playRoomIndex)
-      checkSetPassword(playRoomPassword, playRoomIndex)
-      
-      @logger.debug("@saveDirInfo.removeSaveDir(playRoomIndex) Begin")
-      @saveDirInfo.removeSaveDir(playRoomIndex)
-      @logger.debug("@saveDirInfo.removeSaveDir(playRoomIndex) End")
-      
-      createDir(playRoomIndex)
-      
-      playRoomChangedPassword = getChangedPassword(playRoomPassword)
-      @logger.debug(playRoomChangedPassword, 'playRoomChangedPassword')
-      
-      viewStates = params['viewStates']
-      @logger.debug("viewStates", viewStates)
-      
-      trueSaveFileName = @saveDirInfo.getTrueSaveFileName($playRoomInfo)
-      
-      changeSaveData(trueSaveFileName) do |saveData|
-        saveData['playRoomName'] = playRoomName
-        saveData['playRoomChangedPassword'] = playRoomChangedPassword
-        saveData['chatChannelNames'] = chatChannelNames
-        saveData['canUseExternalImage'] = canUseExternalImage
-        saveData['canVisit'] = canVisit
-        saveData['gameType'] = params['gameType']
-        
-        addViewStatesToSaveData(saveData, viewStates)
-      end
-      
-      sendRoomCreateMessage(playRoomIndex)
-    rescue Exception => e
-      resultText = getLanguageKey( e.to_s )
-    end
-    
-    result = {
-      "resultText" => resultText,
-      "playRoomIndex" => playRoomIndex,
-    }
-    @logger.debug(result, 'result')
-    @logger.debug('createDir finished')
-    
-    return result
+    DodontoF::PlayRoom.new(self, @saveDirInfo).create
   end
   
   def checkCreatePlayRoomPassword(password)

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2003,29 +2003,6 @@ class DodontoFServer
     DodontoF::PlayRoom.new(self, @saveDirInfo).getState(roomNo)
   end
   
-  def getLoginUserNames()
-    userNames = []
-    
-    trueSaveFileName = @saveDirInfo.getTrueSaveFileName($loginUserInfo)
-    @logger.debug(trueSaveFileName, "getLoginUserNames trueSaveFileName")
-    
-    unless( isExist?(trueSaveFileName) )
-      return userNames
-    end
-    
-    @now_getLoginUserNames ||= Time.now.to_i
-    
-    getSaveData(trueSaveFileName) do |userInfos|
-      userInfos.each do |uniqueId, userInfo|
-        next if( isDeleteUserInfo?(uniqueId, userInfo, @now_getLoginUserNames) )
-        userNames << userInfo['userName']
-      end
-    end
-    
-    @logger.debug(userNames, "getLoginUserNames userNames")
-    return userNames
-  end
-  
   def getGameName(gameType)
     require 'diceBotInfos'
     diceBotInfos = DiceBotInfos.new.getInfos

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2439,22 +2439,6 @@ class DodontoFServer
     DodontoF::PlayRoom.new(self, @saveDirInfo).change(params)
   end
   
-  def isSameViewState(viewStates, preViewStateInfo)
-    result = true
-    
-    preViewStateInfo ||= {}
-    
-    viewStates.each do |key, value|
-      unless( value == preViewStateInfo[key] )
-        result = false
-        break
-      end
-    end
-    
-    return result
-  end
-  
-  
   def checkPassword(roomNumber, password)
     
     return true unless( $isPasswordNeedFroDeletePlayRoom )

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2375,49 +2375,6 @@ class DodontoFServer
     DodontoF::PlayRoom.new(self, @saveDirInfo).remove(params)
   end
   
-  
-  def checkRemovePlayRoom(roomNumber, ignoreLoginUser, password, isForce)
-    roomNumberRange = (roomNumber..roomNumber)
-    @logger.debug(roomNumberRange, "checkRemovePlayRoom roomNumberRange")
-    
-    unless( ignoreLoginUser )
-      userNames = getLoginUserNames()
-      userCount = userNames.size
-      @logger.debug(userCount, "checkRemovePlayRoom userCount");
-      
-      if( userCount > 0 )
-        return "userExist"
-      end
-    end
-    
-    if( not password.nil? )
-      if( not checkPassword(roomNumber, password) )
-        return "password"
-      end
-    end
-    
-    if( $unremovablePlayRoomNumbers.include?(roomNumber) )
-      return "unremovablePlayRoomNumber"
-    end
-    
-    lastAccessTimes = getSaveDataLastAccessTimes( roomNumberRange )
-    lastAccessTime = lastAccessTimes[roomNumber]
-    lastAccessTime ||= 0
-    @logger.debug(lastAccessTime, "lastAccessTime")
-    
-    lastAccessTime = 0 if isForce
-    
-    now = Time.now.to_f
-    spendTimes = now - lastAccessTime.to_f
-    @logger.debug(spendTimes, "spendTimes")
-    @logger.debug(spendTimes / 60 / 60, "spendTimes / 60 / 60")
-    if( spendTimes < $deletablePassedSeconds )
-      return "プレイルームNo.#{roomNumber}の最終更新時刻から#{$deletablePassedSeconds}秒が経過していないため削除できません"
-    end
-    
-    return "OK"
-  end
-  
   def getTrueSaveFileName(fileName)
     @saveDirInfo.getTrueSaveFileName($saveFileTempName)
   end

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -1936,25 +1936,6 @@ class DodontoFServer
     DodontoF::PlayRoom.new(self, @saveDirInfo).removeOlds
   end
   
-  def removeOldRoomFromAccessTimes(accessTimes)
-    @logger.debug("removeOldRoom Begin")
-    if( $removeOldPlayRoomLimitDays <= 0 )
-      return accessTimes
-    end
-    
-    @logger.debug(accessTimes, "accessTimes")
-    
-    roomNumbers = getDeleteTargetRoomNumbers(accessTimes)
-    
-    ignoreLoginUser = true
-    password = nil
-    isForce = true
-    result = removePlayRoomByParams(roomNumbers, ignoreLoginUser, password, isForce)
-    @logger.debug(result, "removePlayRoomByParams result")
-    
-    return result
-  end
-  
   def getDeleteTargetRoomNumbers(accessTimes)
     @logger.debug(accessTimes, "getDeleteTargetRoomNumbers accessTimes")
     

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2374,17 +2374,6 @@ class DodontoFServer
     params = getParamsFromRequestData()
     DodontoF::PlayRoom.new(self, @saveDirInfo).remove(params)
   end
-
-  def removePlayRoomData(roomNumber)
-    removeLocalImageTags(roomNumber)
-    @saveDirInfo.removeSaveDir(roomNumber)
-    removeLocalSpaceDir(roomNumber)
-  end
-  
-  def removeLocalImageTags(roomNumber)
-    tagInfos = getImageTags(roomNumber)
-    deleteImages(tagInfos.keys)
-  end
   
   
   def checkRemovePlayRoom(roomNumber, ignoreLoginUser, password, isForce)
@@ -2427,14 +2416,6 @@ class DodontoFServer
     end
     
     return "OK"
-  end
-  
-  
-
-  
-  def removeLocalSpaceDir(roomNumber)
-    dir = getRoomLocalSpaceDirNameByRoomNo(roomNumber)
-    rmdir(dir)
   end
   
   def getTrueSaveFileName(fileName)

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -1201,23 +1201,24 @@ class DodontoFServer
     
     return jsonData
   end
-  
+
   def getWebIfRoomList()
     @logger.debug("getWebIfRoomList Begin")
     minRoom = getWebIfRequestInt('minRoom', 0)
     maxRoom = getWebIfRequestInt('maxRoom', ($saveDataMaxCount - 1))
-    
-    playRoomStates = getPlayRoomStatesLocal(minRoom, maxRoom)
-    
+
+    room = DodontoF::PlayRoom.new(self, @saveDirInfo)
+    playRoomStates = room.getStates(minRoom, maxRoom)
+
     jsonData = {
       "playRoomStates" => playRoomStates,
       "result" => 'OK',
     }
-    
+
     @logger.debug("getWebIfRoomList End")
     return jsonData
   end
-  
+
   def sendWebIfChatText
     @logger.debug("sendWebIfChatText begin")
     
@@ -1928,37 +1929,8 @@ class DodontoFServer
   def getPlayRoomStates()
     params = getParamsFromRequestData()
     @logger.debug(params, "params")
-    
-    minRoom = getMinRoom(params)
-    maxRoom = getMaxRoom(params)
-    playRoomStates = getPlayRoomStatesLocal(minRoom, maxRoom)
-    
-    result = {
-      "minRoom" => minRoom,
-      "maxRoom" => maxRoom,
-      "playRoomStates" => playRoomStates,
-    }
-    
-    @logger.debug(result, "getPlayRoomStatesLocal result");
-    
-    return result
-  end
-  
-  def getPlayRoomStatesLocal(minRoom, maxRoom)
-    roomNumberRange = (minRoom .. maxRoom)
-    playRoomStates = []
-    
-    roomNumberRange.each do |roomNo|
-      
-      @saveDirInfo.setSaveDataDirIndex(roomNo)
-      
-      playRoomState = getPlayRoomState(roomNo)
-      next if( playRoomState.nil? )
-      
-      playRoomStates << playRoomState
-    end
-    
-    return playRoomStates;
+
+    DodontoF::PlayRoom.new(self, @saveDirInfo).getStatesByParams(params)
   end
   
   def getPlayRoomState(roomNo)
@@ -2030,15 +2002,6 @@ class DodontoFServer
     @logger.debug('famousGames', famousGames)
     
     return famousGames
-  end
-  
-  
-  def getMinRoom(params)
-    [[ params['minRoom'], 0 ].max, ($saveDataMaxCount - 1)].min
-  end
-  
-  def getMaxRoom(params)
-    [[ params['maxRoom'], ($saveDataMaxCount - 1) ].min, 0].max
   end
   
   def getLoginInfo()

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -1993,25 +1993,6 @@ class DodontoFServer
     return roomNumbers
   end
   
-  
-  def findEmptyRoomNumber()
-    emptyRoomNubmer = -1
-    
-    roomNumberRange = (0..$saveDataMaxCount)
-    
-    roomNumberRange.each do |roomNumber|
-      @saveDirInfo.setSaveDataDirIndex(roomNumber)
-      trueSaveFileName = @saveDirInfo.getTrueSaveFileName($playRoomInfo)
-      
-      next if( isExist?(trueSaveFileName) )
-      
-      emptyRoomNubmer = roomNumber
-      break
-    end
-    
-    return emptyRoomNubmer
-  end
-  
   def getPlayRoomStates()
     params = getParamsFromRequestData()
     @logger.debug(params, "params")

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2448,17 +2448,6 @@ class DodontoFServer
     DodontoF::PlayRoom.new(self, @saveDirInfo).create(params)
   end
   
-  def checkCreatePlayRoomPassword(password)
-    @logger.debug('checkCreatePlayRoomPassword Begin')
-    @logger.debug(password, 'password')
-    
-    return if( $createPlayRoomPassword.empty? )
-    return if( $createPlayRoomPassword == password )
-    
-    raise "errorPassword"
-  end
-  
-  
   def sendRoomCreateMessage(roomNo)
     chatData = {
       "senderName" => "どどんとふ",

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2442,7 +2442,8 @@ class DodontoFServer
   end
   
   def changePlayRoom()
-    DodontoF::PlayRoom.new(self, @saveDirInfo).change()
+    params = getParamsFromRequestData()
+    DodontoF::PlayRoom.new(self, @saveDirInfo).change(params)
   end
   
   

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2428,20 +2428,7 @@ class DodontoFServer
     params = getParamsFromRequestData()
     DodontoF::PlayRoom.new(self, @saveDirInfo).create(params)
   end
-  
-  def sendRoomCreateMessage(roomNo)
-    chatData = {
-      "senderName" => "どどんとふ",
-      "message" => "＝＝＝＝＝＝＝　プレイルーム　【　No.　#{roomNo}　】　へようこそ！　＝＝＝＝＝＝＝",
-      "color" => "cc0066",
-      "uniqueId" => '0',
-      "channel" => 0,
-    }
-    
-    sendChatMessageByChatData(chatData)
-  end
-  
-  
+
   def addViewStatesToSaveData(saveData, viewStates)
     viewStates['key'] = Time.now.to_f.to_s
     saveData['viewStateInfo'] = viewStates

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -1928,17 +1928,9 @@ class DodontoFServer
     return loginUserList
   end
   
-  
   def getSaveDataLastAccessTimes( roomNumberRange )
     @saveDirInfo.getSaveDataLastAccessTimes($saveFiles.values, roomNumberRange)
   end
-  
-  def getSaveDataLastAccessTime( fileName, roomNo )
-    data = @saveDirInfo.getSaveDataLastAccessTime(fileName, roomNo)
-    time = data[roomNo]
-    return time
-  end
-  
   
   def removeOldPlayRoom()
     roomNumberRange = (0 .. $saveDataMaxCount)

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2442,50 +2442,7 @@ class DodontoFServer
   end
   
   def changePlayRoom()
-    @logger.debug("changePlayRoom begin")
-    
-    resultText = "OK"
-    
-    begin
-      params = getParamsFromRequestData()
-      @logger.debug(params, "params")
-      
-      playRoomPassword = params['playRoomPassword']
-      checkSetPassword(playRoomPassword)
-      
-      playRoomChangedPassword = getChangedPassword(playRoomPassword)
-      @logger.debug('playRoomPassword is get')
-      
-      viewStates = params['viewStates']
-      @logger.debug("viewStates", viewStates)
-      
-      trueSaveFileName = @saveDirInfo.getTrueSaveFileName($playRoomInfo)
-      
-      changeSaveData(trueSaveFileName) do |saveData|
-        saveData['playRoomName'] = params['playRoomName']
-        saveData['playRoomChangedPassword'] = playRoomChangedPassword
-        saveData['chatChannelNames'] = params['chatChannelNames']
-        saveData['canUseExternalImage'] = params['canUseExternalImage']
-        saveData['canVisit'] = params['canVisit']
-        saveData['backgroundImage'] = params['backgroundImage']
-        saveData['gameType'] = params['gameType']
-        
-        preViewStateInfo = saveData['viewStateInfo']
-        unless( isSameViewState(viewStates, preViewStateInfo) )
-          addViewStatesToSaveData(saveData, viewStates)
-        end
-        
-      end
-    rescue Exception => e
-      resultText = getLanguageKey( e.to_s )
-    end
-    
-    result = {
-      "resultText" => resultText,
-    }
-    @logger.debug(result, 'changePlayRoom result')
-    
-    return result
+    DodontoF::PlayRoom.new(self, @saveDirInfo).change()
   end
   
   

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -1928,10 +1928,6 @@ class DodontoFServer
     return loginUserList
   end
   
-  def getSaveDataLastAccessTimes( roomNumberRange )
-    @saveDirInfo.getSaveDataLastAccessTimes($saveFiles.values, roomNumberRange)
-  end
-  
   def removeOldPlayRoom()
     DodontoF::PlayRoom.new(self, @saveDirInfo).removeOlds
   end

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2374,47 +2374,7 @@ class DodontoFServer
     params = getParamsFromRequestData()
     DodontoF::PlayRoom.new(self, @saveDirInfo).remove(params)
   end
-  
-  def removePlayRoomByParams(roomNumbers, ignoreLoginUser, password, isForce)
-    @logger.debug(ignoreLoginUser, 'removePlayRoomByParams Begin ignoreLoginUser')
-    
-    deletedRoomNumbers = []
-    errorMessages = []
-    passwordRoomNumbers = []
-    askDeleteRoomNumbers = []
-    
-    roomNumbers.each do |roomNumber|
-      roomNumber = roomNumber.to_i
-      @logger.debug(roomNumber, 'roomNumber')
-      
-      resultText = checkRemovePlayRoom(roomNumber, ignoreLoginUser, password, isForce)
-      @logger.debug(resultText, "checkRemovePlayRoom resultText")
-      
-      case resultText
-      when "OK"
-        removePlayRoomData(roomNumber)
-        deletedRoomNumbers << roomNumber
-      when "password"
-        passwordRoomNumbers << roomNumber
-      when "userExist"
-        askDeleteRoomNumbers << roomNumber
-      else
-        errorMessages << resultText
-      end
-    end
-    
-    result = {
-      "deletedRoomNumbers" => deletedRoomNumbers,
-      "askDeleteRoomNumbers" => askDeleteRoomNumbers,
-      "passwordRoomNumbers" => passwordRoomNumbers,
-      "errorMessages" => errorMessages,
-    }
-    @logger.debug(result, 'result')
-    
-    return result
-  end
-  
-  
+
   def removePlayRoomData(roomNumber)
     removeLocalImageTags(roomNumber)
     @saveDirInfo.removeSaveDir(roomNumber)

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2434,13 +2434,6 @@ class DodontoFServer
     saveData['viewStateInfo'] = viewStates
   end
   
-  def getChangedPassword(pass)
-    return nil if( pass.empty? )
-    
-    salt = [rand(64),rand(64)].pack("C*").tr("\x00-\x3f","A-Za-z0-9./")
-    return pass.crypt(salt)
-  end
-  
   def changePlayRoom()
     params = getParamsFromRequestData()
     DodontoF::PlayRoom.new(self, @saveDirInfo).change(params)

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2428,11 +2428,6 @@ class DodontoFServer
     params = getParamsFromRequestData()
     DodontoF::PlayRoom.new(self, @saveDirInfo).create(params)
   end
-
-  def addViewStatesToSaveData(saveData, viewStates)
-    viewStates['key'] = Time.now.to_f.to_s
-    saveData['viewStateInfo'] = viewStates
-  end
   
   def changePlayRoom()
     params = getParamsFromRequestData()

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2697,63 +2697,11 @@ class DodontoFServer
 
   def checkRoomStatus()
     deleteOldUploadFile()
-    
+
     params = getParamsFromRequestData()
     @logger.debug(params, 'params')
-    
-    roomNumber = params['roomNumber']
-    @logger.debug(roomNumber, 'roomNumber')
-    
-    @saveDirInfo.setSaveDataDirIndex(roomNumber)
-    
-    isMentenanceModeOn = false
-    isWelcomeMessageOn = $isWelcomeMessageOn
-    playRoomName = ''
-    chatChannelNames = nil
-    canUseExternalImage = false
-    canVisit = false
-    isPasswordLocked = false
-    trueSaveFileName = @saveDirInfo.getTrueSaveFileName($playRoomInfo)
-    isExistPlayRoomInfo = ( isExist?(trueSaveFileName) ) 
-    
-    if( isExistPlayRoomInfo )
-      getSaveData(trueSaveFileName) do |saveData|
-        playRoomName = getPlayRoomName(saveData, roomNumber)
-        changedPassword = saveData['playRoomChangedPassword']
-        chatChannelNames = saveData['chatChannelNames']
-        canUseExternalImage = saveData['canUseExternalImage']
-        canVisit = saveData['canVisit']
-        unless( changedPassword.nil? )
-          isPasswordLocked = true
-        end
-      end
-    end
-    
-    adminPassword = params["adminPassword"]
-    if( isMentenanceMode(adminPassword) )
-      isPasswordLocked = false
-      isWelcomeMessageOn = false
-      isMentenanceModeOn = true
-      canVisit = false
-    end
-    
-    @logger.debug("isPasswordLocked", isPasswordLocked);
-    
-    result = {
-      'isRoomExist' => isExistPlayRoomInfo,
-      'roomName' => playRoomName,
-      'roomNumber' => roomNumber,
-      'chatChannelNames' => chatChannelNames,
-      'canUseExternalImage' => canUseExternalImage,
-      'canVisit' => canVisit,
-      'isPasswordLocked' => isPasswordLocked,
-      'isMentenanceModeOn' => isMentenanceModeOn,
-      'isWelcomeMessageOn' => isWelcomeMessageOn,
-    }
-    
-    @logger.debug(result, "checkRoomStatus End result")
-    
-    return result
+
+    DodontoF::PlayRoom.new(self, @saveDirInfo).check(params)
   end
   
   def isMentenanceMode(adminPassword)

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2444,7 +2444,8 @@ class DodontoFServer
   end
   
   def createPlayRoom()
-    DodontoF::PlayRoom.new(self, @saveDirInfo).create
+    params = getParamsFromRequestData()
+    DodontoF::PlayRoom.new(self, @saveDirInfo).create(params)
   end
   
   def checkCreatePlayRoomPassword(password)

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2030,25 +2030,7 @@ class DodontoFServer
   end
   
   def getPlayRoomState(roomNo)
-    
-    # playRoomState = nil
-    playRoomState = {}
-    playRoomState['passwordLockState'] = false
-    playRoomState['index'] = sprintf("%3d", roomNo)
-    playRoomState['playRoomName'] = "（空き部屋）"
-    playRoomState['lastUpdateTime'] = ""
-    playRoomState['canVisit'] = false
-    playRoomState['gameType'] = ''
-    playRoomState['loginUsers'] = []
-    
-    begin
-      playRoomState = getPlayRoomStateLocal(roomNo, playRoomState)
-    rescue Exception => e
-      @logger.error("getPlayRoomStateLocal Exception rescue")
-      @logger.exception(e)
-    end
-    
-    return playRoomState
+    DodontoF::PlayRoom.new(self, @saveDirInfo).getState(roomNo)
   end
   
   def getPlayRoomStateLocal(roomNo, playRoomState)

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2827,7 +2827,7 @@ class DodontoFServer
     getSaveData(trueSaveFileName) do |saveData|
       
       playRoomChangedPassword = saveData['playRoomChangedPassword']
-      passwordMatched = isPasswordMatch?(password, playRoomChangedPassword)
+      passwordMatched = DodontoF::Utils.isPasswordMatch?(password, playRoomChangedPassword)
       
       if @isWebIf
         unless passwordMatched
@@ -2850,13 +2850,6 @@ class DodontoFServer
     
     return result
   end
-  
-  def isPasswordMatch?(password, changedPassword)
-    return true if( changedPassword.nil? )
-    return false if( password.nil? )
-    ( password.crypt(changedPassword) == changedPassword )
-  end
-  
   
   def logout()
     logoutData = getParamsFromRequestData()

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -1933,10 +1933,7 @@ class DodontoFServer
   end
   
   def removeOldPlayRoom()
-    roomNumberRange = (0 .. $saveDataMaxCount)
-    accessTimes = getSaveDataLastAccessTimes( roomNumberRange )
-    result = removeOldRoomFromAccessTimes(accessTimes)
-    return result
+    DodontoF::PlayRoom.new(self, @saveDirInfo).removeOlds
   end
   
   def removeOldRoomFromAccessTimes(accessTimes)

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2394,20 +2394,7 @@ class DodontoFServer
   
   def removePlayRoom()
     params = getParamsFromRequestData()
-    
-    roomNumbers = params['roomNumbers']
-    ignoreLoginUser = params['ignoreLoginUser']
-    password = params['password']
-    password ||= ""
-    isForce = params['isForce']
-    
-    adminPassword = params["adminPassword"]
-    @logger.debug(adminPassword, "removePlayRoom() adminPassword")
-    if( isMentenanceMode(adminPassword) )
-      password = nil
-    end
-    
-    removePlayRoomByParams(roomNumbers, ignoreLoginUser, password, isForce)
+    DodontoF::PlayRoom.new(self, @saveDirInfo).remove(params)
   end
   
   def removePlayRoomByParams(roomNumbers, ignoreLoginUser, password, isForce)

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2033,42 +2033,6 @@ class DodontoFServer
     DodontoF::PlayRoom.new(self, @saveDirInfo).getState(roomNo)
   end
   
-  def getPlayRoomStateLocal(roomNo, playRoomState)
-    playRoomInfoFile = @saveDirInfo.getTrueSaveFileName($playRoomInfo)
-    
-    return playRoomState unless( isExist?(playRoomInfoFile) )
-    
-    playRoomData = nil
-    getSaveData(playRoomInfoFile) do |playRoomDataTmp|
-      playRoomData = playRoomDataTmp
-    end
-    @logger.debug(playRoomData, "playRoomData")
-    
-    return playRoomState if( playRoomData.empty? )
-    
-    playRoomName = getPlayRoomName(playRoomData, roomNo)
-    passwordLockState = (not playRoomData['playRoomChangedPassword'].nil?)
-    canVisit = playRoomData['canVisit']
-    gameType = playRoomData['gameType']
-    timeStamp = getSaveDataLastAccessTime( $saveFiles['chatMessageDataLog'], roomNo )
-    
-    timeString = ""
-    unless( timeStamp.nil? )
-      timeString = "#{timeStamp.strftime('%Y/%m/%d %H:%M:%S')}"
-    end
-    
-    loginUsers = getLoginUserNames()
-    
-    playRoomState['passwordLockState'] = passwordLockState
-    playRoomState['playRoomName'] = playRoomName
-    playRoomState['lastUpdateTime'] = timeString
-    playRoomState['canVisit'] = canVisit
-    playRoomState['gameType'] = gameType
-    playRoomState['loginUsers'] = loginUsers
-    
-    return playRoomState
-  end
-  
   def getLoginUserNames()
     userNames = []
     

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2326,27 +2326,7 @@ class DodontoFServer
     params = getParamsFromRequestData()
     DodontoF::PlayRoom.new(self, @saveDirInfo).change(params)
   end
-  
-  def checkPassword(roomNumber, password)
-    
-    return true unless( $isPasswordNeedFroDeletePlayRoom )
-    
-    @saveDirInfo.setSaveDataDirIndex(roomNumber)
-    trueSaveFileName = @saveDirInfo.getTrueSaveFileName($playRoomInfo)
-    isExistPlayRoomInfo = ( isExist?(trueSaveFileName) ) 
-    
-    return true unless( isExistPlayRoomInfo )
-    
-    matched = false
-    getSaveData(trueSaveFileName) do |saveData|
-      changedPassword = saveData['playRoomChangedPassword']
-      matched = isPasswordMatch?(password, changedPassword)
-    end
-    
-    return matched
-  end
-  
-  
+
   def removePlayRoom()
     params = getParamsFromRequestData()
     DodontoF::PlayRoom.new(self, @saveDirInfo).remove(params)

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2446,20 +2446,6 @@ class DodontoFServer
     DodontoF::PlayRoom.new(self, @saveDirInfo).change(params)
   end
   
-  
-  def checkSetPassword(playRoomPassword, roomNumber = nil)
-    return if( playRoomPassword.empty? )
-    
-    if( roomNumber.nil? )
-      roomNumber = @saveDirInfo.getSaveDataDirIndex
-    end
-    
-    if( $noPasswordPlayRoomNumbers.include?(roomNumber) )
-      raise "noPasswordPlayRoomNumber"
-    end
-  end
-  
-  
   def isSameViewState(viewStates, preViewStateInfo)
     result = true
     

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -1932,33 +1932,6 @@ class DodontoFServer
     DodontoF::PlayRoom.new(self, @saveDirInfo).removeOlds
   end
   
-  def getDeleteTargetRoomNumbers(accessTimes)
-    @logger.debug(accessTimes, "getDeleteTargetRoomNumbers accessTimes")
-    
-    roomNumbers = []
-    
-    accessTimes.each do |index, time|
-      @logger.debug(index, "index")
-      @logger.debug(time, "time")
-      
-      next if( time.nil? ) 
-      
-      timeDiffSeconds = (Time.now - time)
-      @logger.debug(timeDiffSeconds, "timeDiffSeconds")
-      
-      limitSeconds = $removeOldPlayRoomLimitDays * 24 * 60 * 60
-      @logger.debug(limitSeconds, "limitSeconds")
-      
-      if( timeDiffSeconds > limitSeconds )
-        @logger.debug( index, "roomNumbers added index")
-        roomNumbers << index
-      end
-    end
-    
-    @logger.debug(roomNumbers, "roomNumbers")
-    return roomNumbers
-  end
-  
   def getPlayRoomStates()
     params = getParamsFromRequestData()
     @logger.debug(params, "params")

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2684,13 +2684,6 @@ SQL_TEXT
     viewStates['key'] = Time.now.to_f.to_s
     saveData['viewStateInfo'] = viewStates
   end
-  
-  def getChangedPassword(pass)
-    return nil if( pass.empty? )
-    
-    salt = [rand(64),rand(64)].pack("C*").tr("\x00-\x3f","A-Za-z0-9./")
-    return pass.crypt(salt)
-  end
 
   def changePlayRoom()
     params = getParamsFromRequestData()

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2661,47 +2661,7 @@ SQL_TEXT
     params = getParamsFromRequestData()
     DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).remove(params)
   end
-  
-  def removePlayRoomByParams(roomNumbers, ignoreLoginUser, password)
-    @logger.debug(ignoreLoginUser, 'removePlayRoomByParams Begin ignoreLoginUser')
-    
-    deletedRoomNumbers = []
-    errorMessages = []
-    passwordRoomNumbers = []
-    askDeleteRoomNumbers = []
-    
-    roomNumbers.each do |roomNumber|
-      roomNumber = roomNumber.to_i
-      @logger.debug(roomNumber, 'roomNumber')
-      
-      resultText = checkRemovePlayRoom(roomNumber, ignoreLoginUser, password)
-      @logger.debug(resultText, "checkRemovePlayRoom resultText")
-      
-      case resultText
-      when "OK"
-        removePlayRoomData(roomNumber)
-        deletedRoomNumbers << roomNumber
-      when "password"
-        passwordRoomNumbers << roomNumber
-      when "userExist"
-        askDeleteRoomNumbers << roomNumber
-      else
-        errorMessages << resultText
-      end
-    end
-    
-    result = {
-      "deletedRoomNumbers" => deletedRoomNumbers,
-      "askDeleteRoomNumbers" => askDeleteRoomNumbers,
-      "passwordRoomNumbers" => passwordRoomNumbers,
-      "errorMessages" => errorMessages,
-    }
-    @logger.debug(result, 'result')
-    
-    return result
-  end
-  
-  
+
   def removePlayRoomData(roomNumber)
     removeLocalImageTags(roomNumber)
     removeSaveDir(roomNumber)

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2671,48 +2671,6 @@ SQL_TEXT
       end
     end
   end
-  
-  
-  def checkRemovePlayRoom(roomNumber, ignoreLoginUser, password)
-    roomNumberRange = (roomNumber..roomNumber)
-    @logger.debug(roomNumberRange, "checkRemovePlayRoom roomNumberRange")
-    
-    unless( ignoreLoginUser )
-      userNames = getLoginUserNames(roomNumber)
-      userCount = userNames.size
-      @logger.debug(userCount, "checkRemovePlayRoom userCount");
-      
-      if( userCount > 0 )
-        return "userExist"
-      end
-    end
-    
-    if( not password.nil? )
-      if( not checkPassword(roomNumber, password) )
-        return "password"
-      end
-    end
-    
-    if( $unremovablePlayRoomNumbers.include?(roomNumber) )
-      return "unremovablePlayRoomNumber"
-    end
-    
-    lastAccessTimes = getSaveDataLastAccessTimes( roomNumberRange )
-    lastAccessTime = lastAccessTimes[roomNumber]
-    @logger.debug(lastAccessTime, "lastAccessTime")
-    
-    unless( lastAccessTime.nil? )
-      now = Time.now
-      spendTimes = now - lastAccessTime
-      @logger.debug(spendTimes, "spendTimes")
-      @logger.debug(spendTimes / 60 / 60, "spendTimes / 60 / 60")
-      if( spendTimes < $deletablePassedSeconds )
-        return "プレイルームNo.#{roomNumber}の最終更新時刻から#{$deletablePassedSeconds}秒が経過していないため削除できません"
-      end
-    end
-    
-    return "OK"
-  end
 
   def getTrueSaveFileName(fileName)
     @saveDirInfo.getTrueSaveFileName($saveFileTempName)

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2195,44 +2195,7 @@ SQL_TEXT
     @logger.debug(roomNumbers, "roomNumbers")
     return roomNumbers
   end
-  
-  
-  def findEmptyRoomNumber()
-    emptyRoomNubmer = -1
-    
-    command = <<COMMAND_END
-SELECT 
-  IF(
-    (SELECT COUNT(roomNo) FROM rooms)=0,
-    0,
-    (
-      IF(
-        (SELECT MIN(roomNo) FROM rooms)<>0,
-        0,
-        MIN(roomNo+1)
-      ) 
-    )
-  ) AS roomNo
-FROM rooms
-WHERE (roomNo+1) NOT IN (SELECT roomNo FROM rooms)
-COMMAND_END
-    
-    connectDb
-    result = query(command)
-    @logger.debug(result, "findEmptyRoomNumber result")
-    
-    row = result.first
-    row ||= {}
-    @logger.debug(row, "findEmptyRoomNumber row")
-    
-    count = row['roomNo'].to_i
-    
-    emptyRoomNubmer = count
-    @logger.debug(emptyRoomNubmer, 'emptyRoomNubmer')
-    
-    return emptyRoomNubmer
-  end
-  
+
   def getPlayRoomStates()
     @logger.debug("getPlayRoomStates Begin");
     

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2697,19 +2697,6 @@ SQL_TEXT
     DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).change(params)
   end
 
-  def checkSetPassword(playRoomPassword, roomNumber = nil)
-    return if( playRoomPassword.empty? )
-    
-    if( roomNumber.nil? )
-      roomNumber = @saveDirInfo.getSaveDataDirIndex
-    end
-    
-    if( $noPasswordPlayRoomNumbers.include?(roomNumber) )
-      raise "noPasswordPlayRoomNumber"
-    end
-  end
-  
-  
   def isSameViewState(viewStates, preViewStateInfo)
     result = true
     

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2986,11 +2986,6 @@ SQL_TEXT
     DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).check(params)
   end
 
-  def isMentenanceMode(adminPassword)
-    return false if( $mentenanceModePassword.nil? )
-    return ( adminPassword == $mentenanceModePassword )
-  end
-  
   def loginPassword()
     loginData = getParamsFromRequestData()
     @logger.debug(loginData, 'loginData')

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2680,19 +2680,6 @@ SQL_TEXT
     end
   end
 
-  def sendRoomCreateMessage(roomNo)
-    chatData = {
-      "senderName" => "どどんとふ",
-      "message" => "＝＝＝＝＝＝＝　プレイルーム　【　No.　#{roomNo}　】　へようこそ！　＝＝＝＝＝＝＝",
-      "color" => "cc0066",
-      "uniqueId" => '0',
-      "channel" => 0,
-    }
-    
-    sendChatMessageByChatData(chatData)
-  end
-  
-  
   def addViewStatesToSaveData(saveData, viewStates)
     viewStates['key'] = Time.now.to_f.to_s
     saveData['viewStateInfo'] = viewStates

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2693,7 +2693,8 @@ SQL_TEXT
   end
 
   def changePlayRoom()
-    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).change
+    params = getParamsFromRequestData()
+    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).change(params)
   end
 
   def checkSetPassword(playRoomPassword, roomNumber = nil)

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2691,58 +2691,11 @@ SQL_TEXT
     salt = [rand(64),rand(64)].pack("C*").tr("\x00-\x3f","A-Za-z0-9./")
     return pass.crypt(salt)
   end
-  
+
   def changePlayRoom()
-    @logger.debug("changePlayRoom begin")
-    
-    resultText = "OK"
-    
-    begin
-      params = getParamsFromRequestData()
-      @logger.debug(params, "params")
-      
-      playRoomPassword = params['playRoomPassword']
-      checkSetPassword(playRoomPassword)
-      
-      playRoomChangedPassword = getChangedPassword(playRoomPassword)
-      @logger.debug('playRoomPassword is get')
-      
-      viewStates = params['viewStates']
-      @logger.debug("viewStates", viewStates)
-      
-      
-      changePlayRoomData do |saveData|
-        @logger.debug(saveData, 'changePlayRoom() saveData before')
-        saveData['playRoomName'] = params['playRoomName']
-        saveData['playRoomChangedPassword'] = playRoomChangedPassword
-        saveData['chatChannelNames'] = params['chatChannelNames']
-        saveData['canUseExternalImage'] = params['canUseExternalImage']
-        saveData['canVisit'] = params['canVisit']
-        saveData['backgroundImage'] = params['backgroundImage']
-        saveData['gameType'] = params['gameType']
-        
-        preViewStateInfo = saveData['viewStateInfo']
-        unless( isSameViewState(viewStates, preViewStateInfo) )
-          addViewStatesToSaveData(saveData, viewStates)
-        end
-        
-@logger.debug(saveData, 'changePlayRoom() saveData end')
-        
-        saveData
-      end
-    rescue Exception => e
-      resultText = getLanguageKey( e.to_s )
-    end
-    
-    result = {
-      "resultText" => resultText,
-    }
-    @logger.debug(result, 'changePlayRoom result')
-    
-    return result
+    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).change
   end
-  
-  
+
   def checkSetPassword(playRoomPassword, roomNumber = nil)
     return if( playRoomPassword.empty? )
     

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2147,24 +2147,6 @@ SQL_TEXT
     DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).removeOlds
   end
 
-  def removeOldRoomFromAccessTimes(accessTimes)
-    @logger.debug("removeOldRoom Begin")
-    if( $removeOldPlayRoomLimitDays <= 0 )
-      return accessTimes
-    end
-    
-    @logger.debug(accessTimes, "accessTimes")
-    
-    roomNumbers = getDeleteTargetRoomNumbers(accessTimes)
-    
-    ignoreLoginUser = true
-    password = nil
-    result = removePlayRoomByParams(roomNumbers, ignoreLoginUser, password)
-    @logger.debug(result, "removePlayRoomByParams result")
-    
-    return result
-  end
-  
   def getDeleteTargetRoomNumbers(accessTimes)
     @logger.debug(accessTimes, "getDeleteTargetRoomNumbers accessTimes")
     

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2247,34 +2247,10 @@ SQL_TEXT
   
 
   def getPlayRoomStateLocal(roomNo, playRoomState, playRoomData)
-    
-    return playRoomState if( playRoomData.nil? or playRoomData.empty? )
-    
-    playRoomName = getPlayRoomName(playRoomData, roomNo)
-    passwordLockState = (not playRoomData['playRoomChangedPassword'].nil?)
-    canVisit = playRoomData['canVisit']
-    gameType = playRoomData['gameType']
-    
-    timeStamp = getRoomTimeStamp()
-    
-    timeString = ""
-    unless( timeStamp.nil? )
-      timeString = "#{timeStamp.strftime('%Y/%m/%d %H:%M:%S')}"
-    end
-    
-    loginUsers = getLoginUserNames(roomNo)
-    
-    playRoomState['passwordLockState'] = passwordLockState
-    playRoomState['playRoomName'] = playRoomName
-    playRoomState['lastUpdateTime'] = timeString
-    playRoomState['canVisit'] = canVisit
-    playRoomState['gameType'] = gameType
-    playRoomState['loginUsers'] = loginUsers
-    
-    return playRoomState
+    room = DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo)
+    room.getPlayRoomStateLocal(roomNo, playRoomState, playRoomData)
   end
-  
-  
+
   def getRoomTimeStamp(where = nil)
     result = readDb("SELECT MAX(created_at)",
                     :from => "chats",

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2706,7 +2706,8 @@ COMMAND_END
   
   
   def createPlayRoom()
-    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).create
+    params = getParamsFromRequestData()
+    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).create(params)
   end
 
   

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2690,22 +2690,6 @@ SQL_TEXT
     DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).change(params)
   end
 
-  def isSameViewState(viewStates, preViewStateInfo)
-    result = true
-    
-    preViewStateInfo ||= {}
-    
-    viewStates.each do |key, value|
-      unless( value == preViewStateInfo[key] )
-        result = false
-        break
-      end
-    end
-    
-    return result
-  end
-  
-  
   def checkPassword(roomNumber, password)
     
     return true unless( $isPasswordNeedFroDeletePlayRoom )

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -38,6 +38,8 @@ require 'dodontof/logger'
 require 'dodontof/utils'
 require 'dodontof/dice_adapter'
 
+require 'dodontof_mysqlkai/play_room'
+
 if( $isFirstCgi )
   require 'cgiPatch_forFirstCgi'
 end
@@ -2704,78 +2706,7 @@ COMMAND_END
   
   
   def createPlayRoom()
-    @logger.debug('createPlayRoom begin')
-    
-    resultText = "OK"
-    playRoomIndex = -1
-    begin
-      params = getParamsFromRequestData()
-      @logger.debug(params, "params")
-      
-      checkCreatePlayRoomPassword(params['createPassword'])
-      
-      playRoomName = params['playRoomName']
-      playRoomPassword = params['playRoomPassword']
-      chatChannelNames = params['chatChannelNames']
-      canUseExternalImage = params['canUseExternalImage']
-      
-      canVisit = params['canVisit']
-      playRoomIndex = params['playRoomIndex']
-      
-      if( playRoomIndex == -1 )
-        playRoomIndex = findEmptyRoomNumber()
-        raise "noEmptyPlayRoom" if(playRoomIndex == -1)
-        
-        @logger.debug(playRoomIndex, "findEmptyRoomNumber playRoomIndex")
-      end
-      
-      @logger.debug(playRoomName, 'playRoomName')
-      @logger.debug('playRoomPassword is get')
-      @logger.debug(playRoomIndex, 'playRoomIndex')
-      
-      initSaveFiles(playRoomIndex)
-      checkSetPassword(playRoomPassword, playRoomIndex)
-      
-      @logger.debug("@saveDirInfo.removeSaveDir(playRoomIndex) Begin")
-      removeSaveDir(playRoomIndex)
-      @logger.debug("@saveDirInfo.removeSaveDir(playRoomIndex) End")
-      
-      createDir(playRoomIndex)
-      
-      playRoomChangedPassword = getChangedPassword(playRoomPassword)
-      @logger.debug(playRoomChangedPassword, 'playRoomChangedPassword')
-      
-      viewStates = params['viewStates']
-      @logger.debug("viewStates", viewStates)
-      
-      
-      changePlayRoomData do |saveData|
-        saveData['playRoomName'] = playRoomName
-        saveData['playRoomChangedPassword'] = playRoomChangedPassword
-        saveData['chatChannelNames'] = chatChannelNames
-        saveData['canUseExternalImage'] = canUseExternalImage
-        saveData['canVisit'] = canVisit
-        saveData['gameType'] = params['gameType']
-        
-        addViewStatesToSaveData(saveData, viewStates)
-        
-        saveData
-      end
-      
-      sendRoomCreateMessage(playRoomIndex)
-    rescue Exception => e
-      @logger.exception(e)
-      resultText = getLanguageKey( e.to_s )
-    end
-    
-    result = {
-      "resultText" => resultText,
-      "playRoomIndex" => playRoomIndex,
-    }
-    @logger.debug(result, 'result')
-    @logger.debug('createDir finished')
-    
-    return result
+    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).create
   end
 
   

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2680,11 +2680,6 @@ SQL_TEXT
     end
   end
 
-  def addViewStatesToSaveData(saveData, viewStates)
-    viewStates['key'] = Time.now.to_f.to_s
-    saveData['viewStateInfo'] = viewStates
-  end
-
   def changePlayRoom()
     params = getParamsFromRequestData()
     DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).change(params)

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2681,19 +2681,7 @@ SQL_TEXT
   
   def removePlayRoom()
     params = getParamsFromRequestData()
-    
-    roomNumbers = params['roomNumbers']
-    ignoreLoginUser = params['ignoreLoginUser']
-    password = params['password']
-    password ||= ""
-    
-    adminPassword = params["adminPassword"]
-    @logger.debug(adminPassword, "removePlayRoom() adminPassword")
-    if( isMentenanceMode(adminPassword) )
-      password = nil
-    end
-    
-    removePlayRoomByParams(roomNumbers, ignoreLoginUser, password)
+    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).remove(params)
   end
   
   def removePlayRoomByParams(roomNumbers, ignoreLoginUser, password)

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -3134,7 +3134,7 @@ SQL_TEXT
       result['visiterMode'] = true
     else
       playRoomChangedPassword = saveData['playRoomChangedPassword']
-      if( isPasswordMatch?(password, playRoomChangedPassword) )
+      if( DodontoF::Utils.isPasswordMatch?(password, playRoomChangedPassword) )
         result['resultText'] = "OK"
       else
         result['resultText'] = "passwordMismatch"
@@ -3143,13 +3143,7 @@ SQL_TEXT
     
     return result
   end
-  
-  def isPasswordMatch?(password, changedPassword)
-    return true if( changedPassword.nil? )
-    ( password.crypt(changedPassword) == changedPassword )
-  end
-  
-  
+
   def logout()
     logoutData = getParamsFromRequestData()
     @logger.debug(logoutData, 'logoutData')

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2084,14 +2084,7 @@ SQL_TEXT
     now = Time.now.to_i
     return (now - $loginTimeOut)
   end
-  
-  
-  def getPlayRoomName(saveData, index)
-    playRoomName = saveData['playRoomName']
-    playRoomName ||= "プレイルームNo.#{index}"
-    return playRoomName
-  end
-  
+
   def getLoginUserCountList( roomNumberRange )
     loginUserCountList = {}
     roomNumberRange.each{|i| loginUserCountList[i] = 0 }

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2123,25 +2123,6 @@ SQL_TEXT
     
     return loginUserList
   end
-  
-  
-  def getSaveDataLastAccessTimes( roomNumberRange )
-    
-    @logger.debug(roomNumberRange, "getSaveDataLastAccessTimes roomNumberRange")
-    
-    result = {}
-    
-    roomNumberRange.each do |roomNo|
-      where = {"roomNo >= ? " => roomNo }
-      time = getRoomTimeStamp(where)
-      
-      result[roomNo] = time
-    end
-    
-    @logger.debug(result, "getSaveDataLastAccessTimes result")
-    
-    return result
-  end
 
   def removeOldPlayRoom()
     DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).removeOlds

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2662,18 +2662,6 @@ SQL_TEXT
     DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).remove(params)
   end
 
-  def removePlayRoomData(roomNumber)
-    removeLocalImageTags(roomNumber)
-    removeSaveDir(roomNumber)
-    removeLocalSpaceDir(roomNumber)
-  end
-  
-  def removeLocalImageTags(roomNumber)
-    tagInfos = getImageTags(roomNumber)
-    deleteImages(tagInfos.keys)
-  end
-  
-  
   def removeSaveDir(roomNo)
     @saveDirInfo.removeSaveDir(roomNo)
     
@@ -2725,15 +2713,7 @@ SQL_TEXT
     
     return "OK"
   end
-  
-  
 
-  
-  def removeLocalSpaceDir(roomNumber)
-    dir = getRoomLocalSpaceDirNameByRoomNo(roomNumber)
-    rmdir(dir)
-  end
-  
   def getTrueSaveFileName(fileName)
     @saveDirInfo.getTrueSaveFileName($saveFileTempName)
   end

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2142,15 +2142,11 @@ SQL_TEXT
     
     return result
   end
-  
-  
+
   def removeOldPlayRoom()
-    roomNumberRange = (0 .. $saveDataMaxCount)
-    accessTimes = getSaveDataLastAccessTimes( roomNumberRange )
-    result = removeOldRoomFromAccessTimes(accessTimes)
-    return result
+    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).removeOlds
   end
-  
+
   def removeOldRoomFromAccessTimes(accessTimes)
     @logger.debug("removeOldRoom Begin")
     if( $removeOldPlayRoomLimitDays <= 0 )

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2255,24 +2255,7 @@ SQL_TEXT
                      :where => {"roomNo = ? " => roomNo})
     return (not result.empty?)
   end
-  
-  
-  def getLoginUserNames(roomNo)
-    userNames = []
-    
-    unless( existRoom?(roomNo) )
-      return userNames
-    end
-    
-    deleteUserInfo(roomNo)
-    
-    users = getAllUsersData(roomNo)
-    userNames = users.collect{|i| i['userNames']}
-    
-    @logger.debug(userNames, "getLoginUserNames userNames")
-    return userNames
-  end
-  
+
   def getAllUsersData(roomNo = nil)
     tableName = 'users'
     

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2128,33 +2128,6 @@ SQL_TEXT
     DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).removeOlds
   end
 
-  def getDeleteTargetRoomNumbers(accessTimes)
-    @logger.debug(accessTimes, "getDeleteTargetRoomNumbers accessTimes")
-    
-    roomNumbers = []
-    
-    accessTimes.each do |index, time|
-      @logger.debug(index, "index")
-      @logger.debug(time, "time")
-      
-      next if( time.nil? ) 
-      
-      timeDiffSeconds = (Time.now - time)
-      @logger.debug(timeDiffSeconds, "timeDiffSeconds")
-      
-      limitSeconds = $removeOldPlayRoomLimitDays * 24 * 60 * 60
-      @logger.debug(limitSeconds, "limitSeconds")
-      
-      if( timeDiffSeconds > limitSeconds )
-        @logger.debug( index, "roomNumbers added index")
-        roomNumbers << index
-      end
-    end
-    
-    @logger.debug(roomNumbers, "roomNumbers")
-    return roomNumbers
-  end
-
   def getPlayRoomStates()
     @logger.debug("getPlayRoomStates Begin");
     

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2716,19 +2716,7 @@ COMMAND_END
       yield(data)
     end
   end
-  
-  
-  def checkCreatePlayRoomPassword(password)
-    @logger.debug('checkCreatePlayRoomPassword Begin')
-    @logger.debug(password, 'password')
-    
-    return if( $createPlayRoomPassword.empty? )
-    return if( $createPlayRoomPassword == password )
-    
-    raise "errorPassword"
-  end
-  
-  
+
   def sendRoomCreateMessage(roomNo)
     chatData = {
       "senderName" => "どどんとふ",

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2984,68 +2984,15 @@ SQL_TEXT
     end
     
   end
-  
+
   def checkRoomStatus()
     deleteOldUploadFile()
-    
+
     params = getParamsFromRequestData()
     @logger.debug(params, 'params')
-    
-    roomNumber = params['roomNumber']
-    @logger.debug(roomNumber, 'roomNumber')
-    
-    @saveDirInfo.setSaveDataDirIndex(roomNumber)
-    
-    isMentenanceModeOn = false
-    isWelcomeMessageOn = $isWelcomeMessageOn
-    playRoomName = ''
-    chatChannelNames = nil
-    canUseExternalImage = false
-    canVisit = false
-    isPasswordLocked = false
-    
-    isRoomExist = existRoom?
-    @logger.debug(isRoomExist, "checkRoomStatus isRoomExist")
-    
-    if( isRoomExist )
-      saveData = getPlayRoomData()
-      playRoomName = getPlayRoomName(saveData, roomNumber)
-      changedPassword = saveData['playRoomChangedPassword']
-      chatChannelNames = saveData['chatChannelNames']
-      canUseExternalImage = saveData['canUseExternalImage']
-      canVisit = saveData['canVisit']
-      unless( changedPassword.nil? )
-        isPasswordLocked = true
-      end
-    end
-    
-    adminPassword = params["adminPassword"]
-    if( isMentenanceMode(adminPassword) )
-      isPasswordLocked = false
-      isWelcomeMessageOn = false
-      isMentenanceModeOn = true
-      canVisit = false
-    end
-    
-    @logger.debug("isPasswordLocked", isPasswordLocked);
-    
-    result = {
-      'isRoomExist' => isRoomExist,
-      'roomName' => playRoomName,
-      'roomNumber' => roomNumber,
-      'chatChannelNames' => chatChannelNames,
-      'canUseExternalImage' => canUseExternalImage,
-      'canVisit' => canVisit,
-      'isPasswordLocked' => isPasswordLocked,
-      'isMentenanceModeOn' => isMentenanceModeOn,
-      'isWelcomeMessageOn' => isWelcomeMessageOn,
-    }
-    
-    @logger.debug(result, "checkRoomStatus End result")
-    
-    return result
+    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).check(params)
   end
-  
+
   def isMentenanceMode(adminPassword)
     return false if( $mentenanceModePassword.nil? )
     return ( adminPassword == $mentenanceModePassword )

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2622,24 +2622,6 @@ SQL_TEXT
     DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).change(params)
   end
 
-  def checkPassword(roomNumber, password)
-    
-    return true unless( $isPasswordNeedFroDeletePlayRoom )
-    
-    @saveDirInfo.setSaveDataDirIndex(roomNumber)
-    
-    return true unless( existRoom? )
-    
-    matched = false
-    
-    saveData = getPlayRoomData()
-    changedPassword = saveData['playRoomChangedPassword']
-    matched = isPasswordMatch?(password, changedPassword)
-    
-    return matched
-  end
-  
-  
   def removePlayRoom()
     params = getParamsFromRequestData()
     DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).remove(params)

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -81,6 +81,54 @@ module DodontoF
       return result
     end
 
+
+    def change()
+      @logger.debug("changePlayRoom begin")
+
+      resultText = "OK"
+
+      begin
+        params = @server.getParamsFromRequestData()
+        @logger.debug(params, "params")
+
+        playRoomPassword = params['playRoomPassword']
+        @server.checkSetPassword(playRoomPassword)
+
+        playRoomChangedPassword = @server.getChangedPassword(playRoomPassword)
+        @logger.debug('playRoomPassword is get')
+
+        viewStates = params['viewStates']
+        @logger.debug("viewStates", viewStates)
+
+        trueSaveFileName = @saveDirInfo.getTrueSaveFileName($playRoomInfo)
+
+        @server.changeSaveData(trueSaveFileName) do |saveData|
+          saveData['playRoomName'] = params['playRoomName']
+          saveData['playRoomChangedPassword'] = playRoomChangedPassword
+          saveData['chatChannelNames'] = params['chatChannelNames']
+          saveData['canUseExternalImage'] = params['canUseExternalImage']
+          saveData['canVisit'] = params['canVisit']
+          saveData['backgroundImage'] = params['backgroundImage']
+          saveData['gameType'] = params['gameType']
+
+          preViewStateInfo = saveData['viewStateInfo']
+          unless( @server.isSameViewState(viewStates, preViewStateInfo) )
+            @server.addViewStatesToSaveData(saveData, viewStates)
+          end
+
+        end
+      rescue Exception => e
+        resultText = DodontoF::Utils.getLanguageKey( e.to_s )
+      end
+
+      result = {
+        "resultText" => resultText,
+      }
+      @logger.debug(result, 'changePlayRoom result')
+
+      return result
+    end
+
   private
 
     def checkCreatePlayRoomPassword(password)

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -300,7 +300,7 @@ module DodontoF
 
       @logger.debug(accessTimes, "accessTimes")
 
-      roomNumbers = @server.getDeleteTargetRoomNumbers(accessTimes)
+      roomNumbers = getDeleteTargetRoomNumbers(accessTimes)
 
       ignoreLoginUser = true
       password = nil
@@ -406,6 +406,33 @@ module DodontoF
       end
 
       return "OK"
+    end
+
+    def getDeleteTargetRoomNumbers(accessTimes)
+      @logger.debug(accessTimes, "getDeleteTargetRoomNumbers accessTimes")
+
+      roomNumbers = []
+
+      accessTimes.each do |index, time|
+        @logger.debug(index, "index")
+        @logger.debug(time, "time")
+
+        next if( time.nil? )
+
+        timeDiffSeconds = (Time.now - time)
+        @logger.debug(timeDiffSeconds, "timeDiffSeconds")
+
+        limitSeconds = $removeOldPlayRoomLimitDays * 24 * 60 * 60
+        @logger.debug(limitSeconds, "limitSeconds")
+
+        if( timeDiffSeconds > limitSeconds )
+          @logger.debug( index, "roomNumbers added index")
+          roomNumbers << index
+        end
+      end
+
+      @logger.debug(roomNumbers, "roomNumbers")
+      return roomNumbers
     end
 
     # アクセス中のユーザ名をすべて取得する

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -39,7 +39,7 @@ module DodontoF
         @logger.debug(playRoomIndex, 'playRoomIndex')
 
         @server.initSaveFiles(playRoomIndex)
-        @server.checkSetPassword(playRoomPassword, playRoomIndex)
+        checkSetPassword(playRoomPassword, playRoomIndex)
 
         @logger.debug("@saveDirInfo.removeSaveDir(playRoomIndex) Begin")
         @saveDirInfo.removeSaveDir(playRoomIndex)
@@ -91,7 +91,7 @@ module DodontoF
         @logger.debug(params, "params")
 
         playRoomPassword = params['playRoomPassword']
-        @server.checkSetPassword(playRoomPassword)
+        checkSetPassword(playRoomPassword)
 
         playRoomChangedPassword = @server.getChangedPassword(playRoomPassword)
         @logger.debug('playRoomPassword is get')
@@ -168,6 +168,18 @@ module DodontoF
       }
 
       @server.sendChatMessageByChatData(chatData)
+    end
+
+    def checkSetPassword(playRoomPassword, roomNumber = nil)
+      return if( playRoomPassword.empty? )
+
+      if( roomNumber.nil? )
+        roomNumber = @saveDirInfo.getSaveDataDirIndex
+      end
+
+      if( $noPasswordPlayRoomNumbers.include?(roomNumber) )
+        raise "noPasswordPlayRoomNumber"
+      end
     end
   end
 end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -319,7 +319,7 @@ module DodontoF
         roomNumber = roomNumber.to_i
         @logger.debug(roomNumber, 'roomNumber')
 
-        resultText = @server.checkRemovePlayRoom(roomNumber, ignoreLoginUser, password, isForce)
+        resultText = checkRemovePlayRoom(roomNumber, ignoreLoginUser, password, isForce)
         @logger.debug(resultText, "checkRemovePlayRoom resultText")
 
         case resultText
@@ -360,6 +360,48 @@ module DodontoF
     def removeLocalSpaceDir(roomNumber)
       dir = @server.getRoomLocalSpaceDirNameByRoomNo(roomNumber)
       DodontoF::Utils.rmdir(dir)
+    end
+
+    def checkRemovePlayRoom(roomNumber, ignoreLoginUser, password, isForce)
+      roomNumberRange = (roomNumber..roomNumber)
+      @logger.debug(roomNumberRange, "checkRemovePlayRoom roomNumberRange")
+
+      unless( ignoreLoginUser )
+        userNames = @server.getLoginUserNames()
+        userCount = userNames.size
+        @logger.debug(userCount, "checkRemovePlayRoom userCount");
+
+        if( userCount > 0 )
+          return "userExist"
+        end
+      end
+
+      if( not password.nil? )
+        if( not @server.checkPassword(roomNumber, password) )
+          return "password"
+        end
+      end
+
+      if( $unremovablePlayRoomNumbers.include?(roomNumber) )
+        return "unremovablePlayRoomNumber"
+      end
+
+      lastAccessTimes = @server.getSaveDataLastAccessTimes( roomNumberRange )
+      lastAccessTime = lastAccessTimes[roomNumber]
+      lastAccessTime ||= 0
+      @logger.debug(lastAccessTime, "lastAccessTime")
+
+      lastAccessTime = 0 if isForce
+
+      now = Time.now.to_f
+      spendTimes = now - lastAccessTime.to_f
+      @logger.debug(spendTimes, "spendTimes")
+      @logger.debug(spendTimes / 60 / 60, "spendTimes / 60 / 60")
+      if( spendTimes < $deletablePassedSeconds )
+        return "プレイルームNo.#{roomNumber}の最終更新時刻から#{$deletablePassedSeconds}秒が経過していないため削除できません"
+      end
+
+      return "OK"
     end
   end
 end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -324,7 +324,7 @@ module DodontoF
 
         case resultText
         when "OK"
-          @server.removePlayRoomData(roomNumber)
+          removePlayRoomData(roomNumber)
           deletedRoomNumbers << roomNumber
         when "password"
           passwordRoomNumbers << roomNumber
@@ -344,6 +344,22 @@ module DodontoF
       @logger.debug(result, 'result')
 
       return result
+    end
+
+    def removePlayRoomData(roomNumber)
+      removeLocalImageTags(roomNumber)
+      @saveDirInfo.removeSaveDir(roomNumber)
+      removeLocalSpaceDir(roomNumber)
+    end
+
+    def removeLocalImageTags(roomNumber)
+      tagInfos = @server.getImageTags(roomNumber)
+      @server.deleteImages(tagInfos.keys)
+    end
+
+    def removeLocalSpaceDir(roomNumber)
+      dir = @server.getRoomLocalSpaceDirNameByRoomNo(roomNumber)
+      DodontoF::Utils.rmdir(dir)
     end
   end
 end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -444,7 +444,7 @@ module DodontoF
       matched = false
       @server.getSaveData(trueSaveFileName) do |saveData|
         changedPassword = saveData['playRoomChangedPassword']
-        matched = @server.isPasswordMatch?(password, changedPassword)
+        matched = DodontoF::Utils.isPasswordMatch?(password, changedPassword)
       end
 
       return matched

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -128,6 +128,27 @@ module DodontoF
       return result
     end
 
+    def getState(roomNo)
+      # playRoomState = nil
+      playRoomState = {}
+      playRoomState['passwordLockState'] = false
+      playRoomState['index'] = sprintf("%3d", roomNo)
+      playRoomState['playRoomName'] = "（空き部屋）"
+      playRoomState['lastUpdateTime'] = ""
+      playRoomState['canVisit'] = false
+      playRoomState['gameType'] = ''
+      playRoomState['loginUsers'] = []
+
+      begin
+        playRoomState = @server.getPlayRoomStateLocal(roomNo, playRoomState)
+      rescue Exception => e
+        @logger.error("getPlayRoomStateLocal Exception rescue")
+        @logger.exception(e)
+      end
+
+      return playRoomState
+    end
+
   private
 
     def checkCreatePlayRoomPassword(password)

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -377,7 +377,7 @@ module DodontoF
       end
 
       if( not password.nil? )
-        if( not @server.checkPassword(roomNumber, password) )
+        if( not checkPassword(roomNumber, password) )
           return "password"
         end
       end
@@ -430,6 +430,24 @@ module DodontoF
 
       @logger.debug(userNames, "getLoginUserNames userNames")
       return userNames
+    end
+
+    def checkPassword(roomNumber, password)
+      return true unless( $isPasswordNeedFroDeletePlayRoom )
+
+      @saveDirInfo.setSaveDataDirIndex(roomNumber)
+      trueSaveFileName = @saveDirInfo.getTrueSaveFileName($playRoomInfo)
+      isExistPlayRoomInfo = ( @server.isExist?(trueSaveFileName) )
+
+      return true unless( isExistPlayRoomInfo )
+
+      matched = false
+      @server.getSaveData(trueSaveFileName) do |saveData|
+        changedPassword = saveData['playRoomChangedPassword']
+        matched = @server.isPasswordMatch?(password, changedPassword)
+      end
+
+      return matched
     end
   end
 end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -141,7 +141,7 @@ module DodontoF
         password = nil
       end
 
-      @server.removePlayRoomByParams(roomNumbers, ignoreLoginUser, password, isForce)
+      removePlayRoomByParams(roomNumbers, ignoreLoginUser, password, isForce)
     end
 
     def removeOlds()
@@ -301,8 +301,47 @@ module DodontoF
       ignoreLoginUser = true
       password = nil
       isForce = true
-      result = @server.removePlayRoomByParams(roomNumbers, ignoreLoginUser, password, isForce)
+      result = removePlayRoomByParams(roomNumbers, ignoreLoginUser, password, isForce)
       @logger.debug(result, "removePlayRoomByParams result")
+
+      return result
+    end
+
+    def removePlayRoomByParams(roomNumbers, ignoreLoginUser, password, isForce)
+      @logger.debug(ignoreLoginUser, 'removePlayRoomByParams Begin ignoreLoginUser')
+
+      deletedRoomNumbers = []
+      errorMessages = []
+      passwordRoomNumbers = []
+      askDeleteRoomNumbers = []
+
+      roomNumbers.each do |roomNumber|
+        roomNumber = roomNumber.to_i
+        @logger.debug(roomNumber, 'roomNumber')
+
+        resultText = @server.checkRemovePlayRoom(roomNumber, ignoreLoginUser, password, isForce)
+        @logger.debug(resultText, "checkRemovePlayRoom resultText")
+
+        case resultText
+        when "OK"
+          @server.removePlayRoomData(roomNumber)
+          deletedRoomNumbers << roomNumber
+        when "password"
+          passwordRoomNumbers << roomNumber
+        when "userExist"
+          askDeleteRoomNumbers << roomNumber
+        else
+          errorMessages << resultText
+        end
+      end
+
+      result = {
+        "deletedRoomNumbers" => deletedRoomNumbers,
+        "askDeleteRoomNumbers" => askDeleteRoomNumbers,
+        "passwordRoomNumbers" => passwordRoomNumbers,
+        "errorMessages" => errorMessages,
+      }
+      @logger.debug(result, 'result')
 
       return result
     end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -63,7 +63,7 @@ module DodontoF
           saveData['canVisit'] = canVisit
           saveData['gameType'] = params['gameType']
 
-          @server.addViewStatesToSaveData(saveData, viewStates)
+          addViewStatesToSaveData(saveData, viewStates)
         end
 
         sendRoomCreateMessage(playRoomIndex)
@@ -112,7 +112,7 @@ module DodontoF
 
           preViewStateInfo = saveData['viewStateInfo']
           unless( isSameViewState(viewStates, preViewStateInfo) )
-            @server.addViewStatesToSaveData(saveData, viewStates)
+            addViewStatesToSaveData(saveData, viewStates)
           end
 
         end
@@ -195,6 +195,11 @@ module DodontoF
       end
 
       return result
+    end
+
+    def addViewStatesToSaveData(saveData, viewStates)
+      viewStates['key'] = Time.now.to_f.to_s
+      saveData['viewStateInfo'] = viewStates
     end
   end
 end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -47,7 +47,7 @@ module DodontoF
 
         @server.createDir(playRoomIndex)
 
-        playRoomChangedPassword = @server.getChangedPassword(playRoomPassword)
+        playRoomChangedPassword = DodontoF::Utils.getChangedPassword(playRoomPassword)
         @logger.debug(playRoomChangedPassword, 'playRoomChangedPassword')
 
         viewStates = params['viewStates']
@@ -93,7 +93,7 @@ module DodontoF
         playRoomPassword = params['playRoomPassword']
         checkSetPassword(playRoomPassword)
 
-        playRoomChangedPassword = @server.getChangedPassword(playRoomPassword)
+        playRoomChangedPassword = DodontoF::Utils.getChangedPassword(playRoomPassword)
         @logger.debug('playRoomPassword is get')
 
         viewStates = params['viewStates']

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -17,7 +17,7 @@ module DodontoF
       begin
         @logger.debug(params, "params")
 
-        @server.checkCreatePlayRoomPassword(params['createPassword'])
+        checkCreatePlayRoomPassword(params['createPassword'])
 
         playRoomName = params['playRoomName']
         playRoomPassword = params['playRoomPassword']
@@ -79,6 +79,18 @@ module DodontoF
       @logger.debug('createDir finished')
 
       return result
+    end
+
+  private
+
+    def checkCreatePlayRoomPassword(password)
+      @logger.debug('checkCreatePlayRoomPassword Begin')
+      @logger.debug(password, 'password')
+
+      return if( $createPlayRoomPassword.empty? )
+      return if( $createPlayRoomPassword == password )
+
+      raise "errorPassword"
     end
   end
 end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -146,7 +146,7 @@ module DodontoF
 
     def removeOlds()
       roomNumberRange = (0 .. $saveDataMaxCount)
-      accessTimes = @server.getSaveDataLastAccessTimes( roomNumberRange )
+      accessTimes = getSaveDataLastAccessTimes( roomNumberRange )
       result = removeOldRoomFromAccessTimes(accessTimes)
       return result
     end
@@ -288,6 +288,10 @@ module DodontoF
       return time
     end
 
+    def getSaveDataLastAccessTimes( roomNumberRange )
+      @saveDirInfo.getSaveDataLastAccessTimes($saveFiles.values, roomNumberRange)
+    end
+
     def removeOldRoomFromAccessTimes(accessTimes)
       @logger.debug("removeOldRoom Begin")
       if( $removeOldPlayRoomLimitDays <= 0 )
@@ -386,7 +390,7 @@ module DodontoF
         return "unremovablePlayRoomNumber"
       end
 
-      lastAccessTimes = @server.getSaveDataLastAccessTimes( roomNumberRange )
+      lastAccessTimes = getSaveDataLastAccessTimes( roomNumberRange )
       lastAccessTime = lastAccessTimes[roomNumber]
       lastAccessTime ||= 0
       @logger.debug(lastAccessTime, "lastAccessTime")

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -1,0 +1,85 @@
+#--*-coding:utf-8-*--
+
+module DodontoF
+  # PlayRoom情報
+  class PlayRoom
+    def initialize(server, saveDirInfo)
+      @logger = DodontoF::Logger.instance
+      @server = server
+      @saveDirInfo = saveDirInfo
+    end
+
+    def create
+      @logger.debug('createPlayRoom begin')
+
+      resultText = "OK"
+      playRoomIndex = -1
+      begin
+        params = @server.getParamsFromRequestData()
+        @logger.debug(params, "params")
+
+        @server.checkCreatePlayRoomPassword(params['createPassword'])
+
+        playRoomName = params['playRoomName']
+        playRoomPassword = params['playRoomPassword']
+        chatChannelNames = params['chatChannelNames']
+        canUseExternalImage = params['canUseExternalImage']
+
+        canVisit = params['canVisit']
+        playRoomIndex = params['playRoomIndex']
+
+        if( playRoomIndex == -1 )
+          playRoomIndex = @server.findEmptyRoomNumber()
+          raise "noEmptyPlayRoom" if(playRoomIndex == -1)
+
+          @logger.debug(playRoomIndex, "findEmptyRoomNumber playRoomIndex")
+        end
+
+        @logger.debug(playRoomName, 'playRoomName')
+        @logger.debug('playRoomPassword is get')
+        @logger.debug(playRoomIndex, 'playRoomIndex')
+
+        @server.initSaveFiles(playRoomIndex)
+        @server.checkSetPassword(playRoomPassword, playRoomIndex)
+
+        @logger.debug("@saveDirInfo.removeSaveDir(playRoomIndex) Begin")
+        @saveDirInfo.removeSaveDir(playRoomIndex)
+        @logger.debug("@saveDirInfo.removeSaveDir(playRoomIndex) End")
+
+        @server.createDir(playRoomIndex)
+
+        playRoomChangedPassword = @server.getChangedPassword(playRoomPassword)
+        @logger.debug(playRoomChangedPassword, 'playRoomChangedPassword')
+
+        viewStates = params['viewStates']
+        @logger.debug("viewStates", viewStates)
+
+        trueSaveFileName = @saveDirInfo.getTrueSaveFileName($playRoomInfo)
+
+        @server.changeSaveData(trueSaveFileName) do |saveData|
+          saveData['playRoomName'] = playRoomName
+          saveData['playRoomChangedPassword'] = playRoomChangedPassword
+          saveData['chatChannelNames'] = chatChannelNames
+          saveData['canUseExternalImage'] = canUseExternalImage
+          saveData['canVisit'] = canVisit
+          saveData['gameType'] = params['gameType']
+
+          @server.addViewStatesToSaveData(saveData, viewStates)
+        end
+
+        @server.sendRoomCreateMessage(playRoomIndex)
+      rescue Exception => e
+        resultText = DodontoF::Utils.getLanguageKey( e.to_s )
+      end
+
+      result = {
+        "resultText" => resultText,
+        "playRoomIndex" => playRoomIndex,
+      }
+      @logger.debug(result, 'result')
+      @logger.debug('createDir finished')
+
+      return result
+    end
+  end
+end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -66,7 +66,7 @@ module DodontoF
           @server.addViewStatesToSaveData(saveData, viewStates)
         end
 
-        @server.sendRoomCreateMessage(playRoomIndex)
+        sendRoomCreateMessage(playRoomIndex)
       rescue Exception => e
         resultText = DodontoF::Utils.getLanguageKey( e.to_s )
       end
@@ -109,6 +109,18 @@ module DodontoF
       end
 
       return emptyRoomNubmer
+    end
+
+    def sendRoomCreateMessage(roomNo)
+      chatData = {
+        "senderName" => "どどんとふ",
+        "message" => "＝＝＝＝＝＝＝　プレイルーム　【　No.　#{roomNo}　】　へようこそ！　＝＝＝＝＝＝＝",
+        "color" => "cc0066",
+        "uniqueId" => '0',
+        "channel" => 0,
+      }
+
+      @server.sendChatMessageByChatData(chatData)
     end
   end
 end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -9,13 +9,12 @@ module DodontoF
       @saveDirInfo = saveDirInfo
     end
 
-    def create
+    def create(params)
       @logger.debug('createPlayRoom begin')
 
       resultText = "OK"
       playRoomIndex = -1
       begin
-        params = @server.getParamsFromRequestData()
         @logger.debug(params, "params")
 
         @server.checkCreatePlayRoomPassword(params['createPassword'])

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -228,6 +228,38 @@ module DodontoF
       return playRoomState
     end
 
+    def getStates(minRoom, maxRoom)
+      roomNumberRange = (minRoom .. maxRoom)
+      playRoomStates = []
+
+      roomNumberRange.each do |roomNo|
+        @saveDirInfo.setSaveDataDirIndex(roomNo)
+
+        playRoomState = getState(roomNo)
+        next if( playRoomState.nil? )
+
+        playRoomStates << playRoomState
+      end
+
+      return playRoomStates;
+    end
+
+    def getStatesByParams(params)
+      minRoom = getMinRoom(params)
+      maxRoom = getMaxRoom(params)
+      playRoomStates = getStates(minRoom, maxRoom)
+
+      result = {
+        "minRoom" => minRoom,
+        "maxRoom" => maxRoom,
+        "playRoomStates" => playRoomStates,
+      }
+
+      @logger.debug(result, "getPlayRoomStatesLocal result");
+
+      return result
+    end
+
   private
 
     def checkCreatePlayRoomPassword(password)
@@ -547,6 +579,14 @@ module DodontoF
     def isMentenanceMode(adminPassword)
       return false if( $mentenanceModePassword.nil? )
       return ( adminPassword == $mentenanceModePassword )
+    end
+
+    def getMinRoom(params)
+      [[ params['minRoom'], 0 ].max, ($saveDataMaxCount - 1)].min
+    end
+
+    def getMaxRoom(params)
+      [[ params['maxRoom'], ($saveDataMaxCount - 1) ].min, 0].max
     end
   end
 end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -28,7 +28,7 @@ module DodontoF
         playRoomIndex = params['playRoomIndex']
 
         if( playRoomIndex == -1 )
-          playRoomIndex = @server.findEmptyRoomNumber()
+          playRoomIndex = findEmptyRoomNumber()
           raise "noEmptyPlayRoom" if(playRoomIndex == -1)
 
           @logger.debug(playRoomIndex, "findEmptyRoomNumber playRoomIndex")
@@ -91,6 +91,24 @@ module DodontoF
       return if( $createPlayRoomPassword == password )
 
       raise "errorPassword"
+    end
+
+    def findEmptyRoomNumber()
+      emptyRoomNubmer = -1
+
+      roomNumberRange = (0..$saveDataMaxCount)
+
+      roomNumberRange.each do |roomNumber|
+        @saveDirInfo.setSaveDataDirIndex(roomNumber)
+        trueSaveFileName = @saveDirInfo.getTrueSaveFileName($playRoomInfo)
+
+        next if( @server.isExist?(trueSaveFileName) )
+
+        emptyRoomNubmer = roomNumber
+        break
+      end
+
+      return emptyRoomNubmer
     end
   end
 end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -240,7 +240,7 @@ module DodontoF
       passwordLockState = (not playRoomData['playRoomChangedPassword'].nil?)
       canVisit = playRoomData['canVisit']
       gameType = playRoomData['gameType']
-      timeStamp = @server.getSaveDataLastAccessTime( $saveFiles['chatMessageDataLog'], roomNo )
+      timeStamp = getSaveDataLastAccessTime( $saveFiles['chatMessageDataLog'], roomNo )
 
       timeString = ""
       unless( timeStamp.nil? )
@@ -257,6 +257,12 @@ module DodontoF
       playRoomState['loginUsers'] = loginUsers
 
       return playRoomState
+    end
+
+    def getSaveDataLastAccessTime( fileName, roomNo )
+      data = @saveDirInfo.getSaveDataLastAccessTime(fileName, roomNo)
+      time = data[roomNo]
+      return time
     end
   end
 end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -128,6 +128,22 @@ module DodontoF
       return result
     end
 
+    def remove(params)
+      roomNumbers = params['roomNumbers']
+      ignoreLoginUser = params['ignoreLoginUser']
+      password = params['password']
+      password ||= ""
+      isForce = params['isForce']
+
+      adminPassword = params["adminPassword"]
+      @logger.debug(adminPassword, "removePlayRoom() adminPassword")
+      if( @server.isMentenanceMode(adminPassword) )
+        password = nil
+      end
+
+      @server.removePlayRoomByParams(roomNumbers, ignoreLoginUser, password, isForce)
+    end
+
     def getState(roomNo)
       # playRoomState = nil
       playRoomState = {}

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -137,7 +137,7 @@ module DodontoF
 
       adminPassword = params["adminPassword"]
       @logger.debug(adminPassword, "removePlayRoom() adminPassword")
-      if( @server.isMentenanceMode(adminPassword) )
+      if( isMentenanceMode(adminPassword) )
         password = nil
       end
 
@@ -181,7 +181,7 @@ module DodontoF
       end
 
       adminPassword = params["adminPassword"]
-      if( @server.isMentenanceMode(adminPassword) )
+      if( isMentenanceMode(adminPassword) )
         isPasswordLocked = false
         isWelcomeMessageOn = false
         isMentenanceModeOn = true
@@ -542,6 +542,11 @@ module DodontoF
       end
 
       return matched
+    end
+
+    def isMentenanceMode(adminPassword)
+      return false if( $mentenanceModePassword.nil? )
+      return ( adminPassword == $mentenanceModePassword )
     end
   end
 end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -151,6 +151,62 @@ module DodontoF
       return result
     end
 
+    def check(params)
+      roomNumber = params['roomNumber']
+      @logger.debug(roomNumber, 'roomNumber')
+
+      @saveDirInfo.setSaveDataDirIndex(roomNumber)
+
+      isMentenanceModeOn = false
+      isWelcomeMessageOn = $isWelcomeMessageOn
+      playRoomName = ''
+      chatChannelNames = nil
+      canUseExternalImage = false
+      canVisit = false
+      isPasswordLocked = false
+      trueSaveFileName = @saveDirInfo.getTrueSaveFileName($playRoomInfo)
+      isExistPlayRoomInfo = ( @server.isExist?(trueSaveFileName) ) 
+
+      if( isExistPlayRoomInfo )
+        @server.getSaveData(trueSaveFileName) do |saveData|
+          playRoomName = @server.getPlayRoomName(saveData, roomNumber)
+          changedPassword = saveData['playRoomChangedPassword']
+          chatChannelNames = saveData['chatChannelNames']
+          canUseExternalImage = saveData['canUseExternalImage']
+          canVisit = saveData['canVisit']
+          unless( changedPassword.nil? )
+            isPasswordLocked = true
+          end
+        end
+      end
+
+      adminPassword = params["adminPassword"]
+      if( @server.isMentenanceMode(adminPassword) )
+        isPasswordLocked = false
+        isWelcomeMessageOn = false
+        isMentenanceModeOn = true
+        canVisit = false
+      end
+
+      @logger.debug("isPasswordLocked", isPasswordLocked);
+
+      result = {
+        'isRoomExist' => isExistPlayRoomInfo,
+        'roomName' => playRoomName,
+        'roomNumber' => roomNumber,
+        'chatChannelNames' => chatChannelNames,
+        'canUseExternalImage' => canUseExternalImage,
+        'canVisit' => canVisit,
+        'isPasswordLocked' => isPasswordLocked,
+        'isMentenanceModeOn' => isMentenanceModeOn,
+        'isWelcomeMessageOn' => isWelcomeMessageOn,
+      }
+
+      @logger.debug(result, "checkRoomStatus End result")
+
+      return result
+    end
+
     def getState(roomNo)
       # playRoomState = nil
       playRoomState = {}

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -169,7 +169,7 @@ module DodontoF
 
       if( isExistPlayRoomInfo )
         @server.getSaveData(trueSaveFileName) do |saveData|
-          playRoomName = @server.getPlayRoomName(saveData, roomNumber)
+          playRoomName = getPlayRoomName(saveData, roomNumber)
           changedPassword = saveData['playRoomChangedPassword']
           chatChannelNames = saveData['chatChannelNames']
           canUseExternalImage = saveData['canUseExternalImage']
@@ -315,7 +315,7 @@ module DodontoF
 
       return playRoomState if( playRoomData.empty? )
 
-      playRoomName = @server.getPlayRoomName(playRoomData, roomNo)
+      playRoomName = getPlayRoomName(playRoomData, roomNo)
       passwordLockState = (not playRoomData['playRoomChangedPassword'].nil?)
       canVisit = playRoomData['canVisit']
       gameType = playRoomData['gameType']
@@ -517,6 +517,13 @@ module DodontoF
 
       @logger.debug(userNames, "getLoginUserNames userNames")
       return userNames
+    end
+
+    # プレイルーム名を取得する
+    def getPlayRoomName(saveData, index)
+      playRoomName = saveData['playRoomName']
+      playRoomName ||= "プレイルームNo.#{index}"
+      return playRoomName
     end
 
     def checkPassword(roomNumber, password)

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -147,7 +147,7 @@ module DodontoF
     def removeOlds()
       roomNumberRange = (0 .. $saveDataMaxCount)
       accessTimes = @server.getSaveDataLastAccessTimes( roomNumberRange )
-      result = @server.removeOldRoomFromAccessTimes(accessTimes)
+      result = removeOldRoomFromAccessTimes(accessTimes)
       return result
     end
 
@@ -286,6 +286,25 @@ module DodontoF
       data = @saveDirInfo.getSaveDataLastAccessTime(fileName, roomNo)
       time = data[roomNo]
       return time
+    end
+
+    def removeOldRoomFromAccessTimes(accessTimes)
+      @logger.debug("removeOldRoom Begin")
+      if( $removeOldPlayRoomLimitDays <= 0 )
+        return accessTimes
+      end
+
+      @logger.debug(accessTimes, "accessTimes")
+
+      roomNumbers = @server.getDeleteTargetRoomNumbers(accessTimes)
+
+      ignoreLoginUser = true
+      password = nil
+      isForce = true
+      result = @server.removePlayRoomByParams(roomNumbers, ignoreLoginUser, password, isForce)
+      @logger.debug(result, "removePlayRoomByParams result")
+
+      return result
     end
   end
 end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -111,7 +111,7 @@ module DodontoF
           saveData['gameType'] = params['gameType']
 
           preViewStateInfo = saveData['viewStateInfo']
-          unless( @server.isSameViewState(viewStates, preViewStateInfo) )
+          unless( isSameViewState(viewStates, preViewStateInfo) )
             @server.addViewStatesToSaveData(saveData, viewStates)
           end
 
@@ -180,6 +180,21 @@ module DodontoF
       if( $noPasswordPlayRoomNumbers.include?(roomNumber) )
         raise "noPasswordPlayRoomNumber"
       end
+    end
+
+    def isSameViewState(viewStates, preViewStateInfo)
+      result = true
+
+      preViewStateInfo ||= {}
+
+      viewStates.each do |key, value|
+        unless( value == preViewStateInfo[key] )
+          result = false
+          break
+        end
+      end
+
+      return result
     end
   end
 end

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -82,13 +82,12 @@ module DodontoF
     end
 
 
-    def change()
+    def change(params)
       @logger.debug("changePlayRoom begin")
 
       resultText = "OK"
 
       begin
-        params = @server.getParamsFromRequestData()
         @logger.debug(params, "params")
 
         playRoomPassword = params['playRoomPassword']

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -144,6 +144,13 @@ module DodontoF
       @server.removePlayRoomByParams(roomNumbers, ignoreLoginUser, password, isForce)
     end
 
+    def removeOlds()
+      roomNumberRange = (0 .. $saveDataMaxCount)
+      accessTimes = @server.getSaveDataLastAccessTimes( roomNumberRange )
+      result = @server.removeOldRoomFromAccessTimes(accessTimes)
+      return result
+    end
+
     def getState(roomNo)
       # playRoomState = nil
       playRoomState = {}

--- a/src_ruby/dodontof/utils.rb
+++ b/src_ruby/dodontof/utils.rb
@@ -96,5 +96,15 @@ module DodontoF
       '###Language:' + key + '###'
     end
     module_function :getLanguageKey
+
+    # 指定の文字列(パスワード)をソルトを用いてエンコードして返す
+    # 生の状態でパスワードを保存するのを避けるための措置
+    def getChangedPassword(pass)
+      return nil if( pass.empty? )
+
+      salt = [rand(64),rand(64)].pack("C*").tr("\x00-\x3f","A-Za-z0-9./")
+      return pass.crypt(salt)
+    end
+    module_function :getChangedPassword
   end
 end

--- a/src_ruby/dodontof/utils.rb
+++ b/src_ruby/dodontof/utils.rb
@@ -106,5 +106,16 @@ module DodontoF
       return pass.crypt(salt)
     end
     module_function :getChangedPassword
+
+    # 生パスワード(password)と
+    # ソルトによりエンコードされたパスワード(changedPassword)が
+    # その実態として一致するかチェックします
+    # see also: getChangedPassword
+    def isPasswordMatch?(password, changedPassword)
+      return true if( changedPassword.nil? )
+      return false if( password.nil? )
+      ( password.crypt(changedPassword) == changedPassword )
+    end
+    module_function :isPasswordMatch?
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -191,7 +191,7 @@ module DodontoF_MySqlKai
         password = nil
       end
 
-      @server.removePlayRoomByParams(roomNumbers, ignoreLoginUser, password)
+      removePlayRoomByParams(roomNumbers, ignoreLoginUser, password)
     end
 
     def removeOlds()
@@ -310,8 +310,49 @@ COMMAND_END
 
       ignoreLoginUser = true
       password = nil
-      result = @server.removePlayRoomByParams(roomNumbers, ignoreLoginUser, password)
+      result = removePlayRoomByParams(roomNumbers, ignoreLoginUser, password)
       @logger.debug(result, "removePlayRoomByParams result")
+
+      return result
+    end
+
+    # DodontoF::PlayRoomとはisForceパラメタの存在に違いがあるので注意
+    def removePlayRoomByParams(roomNumbers, ignoreLoginUser, password)
+      @logger.debug(ignoreLoginUser, 'removePlayRoomByParams Begin ignoreLoginUser')
+
+      deletedRoomNumbers = []
+      errorMessages = []
+      passwordRoomNumbers = []
+      askDeleteRoomNumbers = []
+
+      roomNumbers.each do |roomNumber|
+        roomNumber = roomNumber.to_i
+        @logger.debug(roomNumber, 'roomNumber')
+
+        # DodontoF::PlayRoomとはisForceパラメタの存在に違いがあるので注意
+        resultText = @server.checkRemovePlayRoom(roomNumber, ignoreLoginUser, password)
+        @logger.debug(resultText, "checkRemovePlayRoom resultText")
+
+        case resultText
+        when "OK"
+          @server.removePlayRoomData(roomNumber)
+          deletedRoomNumbers << roomNumber
+        when "password"
+          passwordRoomNumbers << roomNumber
+        when "userExist"
+          askDeleteRoomNumbers << roomNumber
+        else
+          errorMessages << resultText
+        end
+      end
+
+      result = {
+        "deletedRoomNumbers" => deletedRoomNumbers,
+        "askDeleteRoomNumbers" => askDeleteRoomNumbers,
+        "passwordRoomNumbers" => passwordRoomNumbers,
+        "errorMessages" => errorMessages,
+      }
+      @logger.debug(result, 'result')
 
       return result
     end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -306,7 +306,7 @@ COMMAND_END
 
       @logger.debug(accessTimes, "accessTimes")
 
-      roomNumbers = @server.getDeleteTargetRoomNumbers(accessTimes)
+      roomNumbers = getDeleteTargetRoomNumbers(accessTimes)
 
       ignoreLoginUser = true
       password = nil
@@ -482,6 +482,33 @@ COMMAND_END
       @logger.debug(result, "getSaveDataLastAccessTimes result")
 
       return result
+    end
+
+    def getDeleteTargetRoomNumbers(accessTimes)
+      @logger.debug(accessTimes, "getDeleteTargetRoomNumbers accessTimes")
+
+      roomNumbers = []
+
+      accessTimes.each do |index, time|
+        @logger.debug(index, "index")
+        @logger.debug(time, "time")
+
+        next if( time.nil? )
+
+        timeDiffSeconds = (Time.now - time)
+        @logger.debug(timeDiffSeconds, "timeDiffSeconds")
+
+        limitSeconds = $removeOldPlayRoomLimitDays * 24 * 60 * 60
+        @logger.debug(limitSeconds, "limitSeconds")
+
+        if( timeDiffSeconds > limitSeconds )
+          @logger.debug( index, "roomNumbers added index")
+          roomNumbers << index
+        end
+      end
+
+      @logger.debug(roomNumbers, "roomNumbers")
+      return roomNumbers
     end
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -90,6 +90,62 @@ module DodontoF_MySqlKai
       return result
     end
 
+    def change()
+      @logger.debug("changePlayRoom begin")
+
+      resultText = "OK"
+
+      begin
+        params = @server.getParamsFromRequestData()
+        @logger.debug(params, "params")
+
+        playRoomPassword = params['playRoomPassword']
+        @server.checkSetPassword(playRoomPassword)
+
+        playRoomChangedPassword = @server.getChangedPassword(playRoomPassword)
+        @logger.debug('playRoomPassword is get')
+
+        viewStates = params['viewStates']
+        @logger.debug("viewStates", viewStates)
+
+        # DodontoF::PlayRoomとの違いに注意
+        # 1. trueSaveFileNameをこちらでは求めない
+        # 2. changePlayRoomDataとchangeSaveData(trueSaveFileName)
+
+        changePlayRoomData do |saveData|
+          @logger.debug(saveData, 'changePlayRoom() saveData before')
+          saveData['playRoomName'] = params['playRoomName']
+          saveData['playRoomChangedPassword'] = playRoomChangedPassword
+          saveData['chatChannelNames'] = params['chatChannelNames']
+          saveData['canUseExternalImage'] = params['canUseExternalImage']
+          saveData['canVisit'] = params['canVisit']
+          saveData['backgroundImage'] = params['backgroundImage']
+          saveData['gameType'] = params['gameType']
+
+          preViewStateInfo = saveData['viewStateInfo']
+          unless( @server.isSameViewState(viewStates, preViewStateInfo) )
+            @server.addViewStatesToSaveData(saveData, viewStates)
+          end
+
+          @logger.debug(saveData, 'changePlayRoom() saveData end')
+
+          # DodontoF::PlayRoomとの違いに注意
+          # changePlayRoomData()はchangeSaveData()と違い
+          # iteratorからreturnを受け利用する
+          saveData
+        end
+      rescue Exception => e
+        resultText = DodontoF::Utils.getLanguageKey( e.to_s )
+      end
+
+      result = {
+        "resultText" => resultText,
+      }
+      @logger.debug(result, 'changePlayRoom result')
+
+      return result
+    end
+
   private
 
     def checkCreatePlayRoomPassword(password)

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -48,7 +48,7 @@ module DodontoF_MySqlKai
 
         @server.createDir(playRoomIndex)
 
-        playRoomChangedPassword = @server.getChangedPassword(playRoomPassword)
+        playRoomChangedPassword = DodontoF::Utils.getChangedPassword(playRoomPassword)
         @logger.debug(playRoomChangedPassword, 'playRoomChangedPassword')
 
         viewStates = params['viewStates']
@@ -101,7 +101,7 @@ module DodontoF_MySqlKai
         playRoomPassword = params['playRoomPassword']
         checkSetPassword(playRoomPassword)
 
-        playRoomChangedPassword = @server.getChangedPassword(playRoomPassword)
+        playRoomChangedPassword = DodontoF::Utils.getChangedPassword(playRoomPassword)
         @logger.debug('playRoomPassword is get')
 
         viewStates = params['viewStates']

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -178,6 +178,22 @@ module DodontoF_MySqlKai
       return playRoomState
     end
 
+
+    def remove(params)
+      roomNumbers = params['roomNumbers']
+      ignoreLoginUser = params['ignoreLoginUser']
+      password = params['password']
+      password ||= ""
+
+      adminPassword = params["adminPassword"]
+      @logger.debug(adminPassword, "removePlayRoom() adminPassword")
+      if( @server.isMentenanceMode(adminPassword) )
+        password = nil
+      end
+
+      @server.removePlayRoomByParams(roomNumbers, ignoreLoginUser, password)
+    end
+
   private
 
     def checkCreatePlayRoomPassword(password)

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -194,6 +194,13 @@ module DodontoF_MySqlKai
       @server.removePlayRoomByParams(roomNumbers, ignoreLoginUser, password)
     end
 
+    def removeOlds()
+      roomNumberRange = (0 .. $saveDataMaxCount)
+      accessTimes = @server.getSaveDataLastAccessTimes( roomNumberRange )
+      result = @server.removeOldRoomFromAccessTimes(accessTimes)
+      return result
+    end
+
   private
 
     def checkCreatePlayRoomPassword(password)

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -197,7 +197,7 @@ module DodontoF_MySqlKai
     def removeOlds()
       roomNumberRange = (0 .. $saveDataMaxCount)
       accessTimes = @server.getSaveDataLastAccessTimes( roomNumberRange )
-      result = @server.removeOldRoomFromAccessTimes(accessTimes)
+      result = removeOldRoomFromAccessTimes(accessTimes)
       return result
     end
 
@@ -297,5 +297,23 @@ COMMAND_END
     end
 
     # ** DodontoF::PlayRoomと違って、getSaveDataLastAccessTimeの依存性がまだ外に出ているので後回しにした **
+
+    def removeOldRoomFromAccessTimes(accessTimes)
+      @logger.debug("removeOldRoom Begin")
+      if( $removeOldPlayRoomLimitDays <= 0 )
+        return accessTimes
+      end
+
+      @logger.debug(accessTimes, "accessTimes")
+
+      roomNumbers = @server.getDeleteTargetRoomNumbers(accessTimes)
+
+      ignoreLoginUser = true
+      password = nil
+      result = @server.removePlayRoomByParams(roomNumbers, ignoreLoginUser, password)
+      @logger.debug(result, "removePlayRoomByParams result")
+
+      return result
+    end
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -1,0 +1,94 @@
+#--*-coding:utf-8-*--
+
+module DodontoF_MySqlKai
+  # PlayRoom情報
+  class PlayRoom
+    def initialize(server, saveDirInfo)
+      @logger = DodontoF::Logger.instance
+      @server = server
+      @saveDirInfo = saveDirInfo
+    end
+
+    def create
+      @logger.debug('createPlayRoom begin')
+
+      resultText = "OK"
+      playRoomIndex = -1
+      begin
+        params = @server.getParamsFromRequestData()
+        @logger.debug(params, "params")
+
+        @server.checkCreatePlayRoomPassword(params['createPassword'])
+
+        playRoomName = params['playRoomName']
+        playRoomPassword = params['playRoomPassword']
+        chatChannelNames = params['chatChannelNames']
+        canUseExternalImage = params['canUseExternalImage']
+
+        canVisit = params['canVisit']
+        playRoomIndex = params['playRoomIndex']
+
+        if( playRoomIndex == -1 )
+          playRoomIndex = @server.findEmptyRoomNumber()
+          raise "noEmptyPlayRoom" if(playRoomIndex == -1)
+
+          @logger.debug(playRoomIndex, "findEmptyRoomNumber playRoomIndex")
+        end
+
+        @logger.debug(playRoomName, 'playRoomName')
+        @logger.debug('playRoomPassword is get')
+        @logger.debug(playRoomIndex, 'playRoomIndex')
+
+        @server.initSaveFiles(playRoomIndex)
+        @server.checkSetPassword(playRoomPassword, playRoomIndex)
+
+        @logger.debug("@saveDirInfo.removeSaveDir(playRoomIndex) Begin")
+        # DodontoF::PlayRoomとの違い(@server, @saveDirInfo)に注意
+        @server.removeSaveDir(playRoomIndex)
+        @logger.debug("@saveDirInfo.removeSaveDir(playRoomIndex) End")
+
+        @server.createDir(playRoomIndex)
+
+        playRoomChangedPassword = @server.getChangedPassword(playRoomPassword)
+        @logger.debug(playRoomChangedPassword, 'playRoomChangedPassword')
+
+        viewStates = params['viewStates']
+        @logger.debug("viewStates", viewStates)
+
+        # DodontoF::PlayRoomとの違いに注意
+        # 1. trueSaveFileNameをこちらでは求めない
+        # 2. changePlayRoomDataとchangeSaveData(trueSaveFileName)
+
+        @server.changePlayRoomData do |saveData|
+          saveData['playRoomName'] = playRoomName
+          saveData['playRoomChangedPassword'] = playRoomChangedPassword
+          saveData['chatChannelNames'] = chatChannelNames
+          saveData['canUseExternalImage'] = canUseExternalImage
+          saveData['canVisit'] = canVisit
+          saveData['gameType'] = params['gameType']
+
+          @server.addViewStatesToSaveData(saveData, viewStates)
+
+          # DodontoF::PlayRoomとの違いに注意
+          # changePlayRoomData()はchangeSaveData()と違い
+          # iteratorからreturnを受け利用する
+          saveData
+        end
+
+        @server.sendRoomCreateMessage(playRoomIndex)
+      rescue Exception => e
+        @logger.exception(e)
+        resultText = DodontoF::Utils.getLanguageKey( e.to_s )
+      end
+
+      result = {
+        "resultText" => resultText,
+        "playRoomIndex" => playRoomIndex,
+      }
+      @logger.debug(result, 'result')
+      @logger.debug('createDir finished')
+
+      return result
+    end
+  end
+end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -74,7 +74,7 @@ module DodontoF_MySqlKai
           saveData
         end
 
-        @server.sendRoomCreateMessage(playRoomIndex)
+        sendRoomCreateMessage(playRoomIndex)
       rescue Exception => e
         @logger.exception(e)
         resultText = DodontoF::Utils.getLanguageKey( e.to_s )
@@ -139,6 +139,18 @@ COMMAND_END
       @logger.debug(emptyRoomNubmer, 'emptyRoomNubmer')
 
       return emptyRoomNubmer
+    end
+
+    def sendRoomCreateMessage(roomNo)
+      chatData = {
+        "senderName" => "どどんとふ",
+        "message" => "＝＝＝＝＝＝＝　プレイルーム　【　No.　#{roomNo}　】　へようこそ！　＝＝＝＝＝＝＝",
+        "color" => "cc0066",
+        "uniqueId" => '0',
+        "channel" => 0,
+      }
+
+      @server.sendChatMessageByChatData(chatData)
     end
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -154,7 +154,7 @@ module DodontoF_MySqlKai
     def getPlayRoomStateLocal(roomNo, playRoomState, playRoomData)
       return playRoomState if( playRoomData.nil? or playRoomData.empty? )
 
-      playRoomName = @server.getPlayRoomName(playRoomData, roomNo)
+      playRoomName = getPlayRoomName(playRoomData, roomNo)
       passwordLockState = (not playRoomData['playRoomChangedPassword'].nil?)
       canVisit = playRoomData['canVisit']
       gameType = playRoomData['gameType']
@@ -220,7 +220,7 @@ module DodontoF_MySqlKai
 
       if( isRoomExist )
         saveData = @server.getPlayRoomData()
-        playRoomName = @server.getPlayRoomName(saveData, roomNumber)
+        playRoomName = getPlayRoomName(saveData, roomNumber)
         changedPassword = saveData['playRoomChangedPassword']
         chatChannelNames = saveData['chatChannelNames']
         canUseExternalImage = saveData['canUseExternalImage']
@@ -565,6 +565,12 @@ COMMAND_END
 
       @logger.debug(roomNumbers, "roomNumbers")
       return roomNumbers
+    end
+
+    def getPlayRoomName(saveData, index)
+      playRoomName = saveData['playRoomName']
+      playRoomName ||= "プレイルームNo.#{index}"
+      return playRoomName
     end
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -201,6 +201,62 @@ module DodontoF_MySqlKai
       return result
     end
 
+    def check(params)
+      roomNumber = params['roomNumber']
+      @logger.debug(roomNumber, 'roomNumber')
+
+      @saveDirInfo.setSaveDataDirIndex(roomNumber)
+
+      isMentenanceModeOn = false
+      isWelcomeMessageOn = $isWelcomeMessageOn
+      playRoomName = ''
+      chatChannelNames = nil
+      canUseExternalImage = false
+      canVisit = false
+      isPasswordLocked = false
+
+      isRoomExist = @server.existRoom?
+      @logger.debug(isRoomExist, "checkRoomStatus isRoomExist")
+
+      if( isRoomExist )
+        saveData = @server.getPlayRoomData()
+        playRoomName = @server.getPlayRoomName(saveData, roomNumber)
+        changedPassword = saveData['playRoomChangedPassword']
+        chatChannelNames = saveData['chatChannelNames']
+        canUseExternalImage = saveData['canUseExternalImage']
+        canVisit = saveData['canVisit']
+        unless( changedPassword.nil? )
+          isPasswordLocked = true
+        end
+      end
+
+      adminPassword = params["adminPassword"]
+      if( @server.isMentenanceMode(adminPassword) )
+        isPasswordLocked = false
+        isWelcomeMessageOn = false
+        isMentenanceModeOn = true
+        canVisit = false
+      end
+
+      @logger.debug("isPasswordLocked", isPasswordLocked);
+
+      result = {
+        'isRoomExist' => isRoomExist,
+        'roomName' => playRoomName,
+        'roomNumber' => roomNumber,
+        'chatChannelNames' => chatChannelNames,
+        'canUseExternalImage' => canUseExternalImage,
+        'canVisit' => canVisit,
+        'isPasswordLocked' => isPasswordLocked,
+        'isMentenanceModeOn' => isMentenanceModeOn,
+        'isWelcomeMessageOn' => isWelcomeMessageOn,
+      }
+
+      @logger.debug(result, "checkRoomStatus End result")
+
+      return result
+    end
+
   private
 
     def checkCreatePlayRoomPassword(password)

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -66,7 +66,7 @@ module DodontoF_MySqlKai
           saveData['canVisit'] = canVisit
           saveData['gameType'] = params['gameType']
 
-          @server.addViewStatesToSaveData(saveData, viewStates)
+          addViewStatesToSaveData(saveData, viewStates)
 
           # DodontoF::PlayRoomとの違いに注意
           # changePlayRoomData()はchangeSaveData()と違い
@@ -123,7 +123,7 @@ module DodontoF_MySqlKai
 
           preViewStateInfo = saveData['viewStateInfo']
           unless( isSameViewState(viewStates, preViewStateInfo) )
-            @server.addViewStatesToSaveData(saveData, viewStates)
+            addViewStatesToSaveData(saveData, viewStates)
           end
 
           @logger.debug(saveData, 'changePlayRoom() saveData end')
@@ -233,6 +233,11 @@ COMMAND_END
       end
 
       return result
+    end
+
+    def addViewStatesToSaveData(saveData, viewStates)
+      viewStates['key'] = Time.now.to_f.to_s
+      saveData['viewStateInfo'] = viewStates
     end
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -389,7 +389,7 @@ COMMAND_END
       end
 
       if( not password.nil? )
-        if( not @server.checkPassword(roomNumber, password) )
+        if( not checkPassword(roomNumber, password) )
           return "password"
         end
       end
@@ -447,6 +447,23 @@ COMMAND_END
 
       @logger.debug(userNames, "getLoginUserNames userNames")
       return userNames
+    end
+
+    # 実装がDodontoF::PlayRoomと異なるので注意
+    def checkPassword(roomNumber, password)
+      return true unless( $isPasswordNeedFroDeletePlayRoom )
+
+      @saveDirInfo.setSaveDataDirIndex(roomNumber)
+
+      return true unless( @server.existRoom? )
+
+      matched = false
+
+      saveData = @server.getPlayRoomData()
+      changedPassword = saveData['playRoomChangedPassword']
+      matched = @server.isPasswordMatch?(password, changedPassword)
+
+      return matched
     end
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -17,7 +17,7 @@ module DodontoF_MySqlKai
       begin
         @logger.debug(params, "params")
 
-        @server.checkCreatePlayRoomPassword(params['createPassword'])
+        checkCreatePlayRoomPassword(params['createPassword'])
 
         playRoomName = params['playRoomName']
         playRoomPassword = params['playRoomPassword']
@@ -88,6 +88,18 @@ module DodontoF_MySqlKai
       @logger.debug('createDir finished')
 
       return result
+    end
+
+  private
+
+    def checkCreatePlayRoomPassword(password)
+      @logger.debug('checkCreatePlayRoomPassword Begin')
+      @logger.debug(password, 'password')
+
+      return if( $createPlayRoomPassword.empty? )
+      return if( $createPlayRoomPassword == password )
+
+      raise "errorPassword"
     end
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -122,7 +122,7 @@ module DodontoF_MySqlKai
           saveData['gameType'] = params['gameType']
 
           preViewStateInfo = saveData['viewStateInfo']
-          unless( @server.isSameViewState(viewStates, preViewStateInfo) )
+          unless( isSameViewState(viewStates, preViewStateInfo) )
             @server.addViewStatesToSaveData(saveData, viewStates)
           end
 
@@ -218,6 +218,21 @@ COMMAND_END
       if( $noPasswordPlayRoomNumbers.include?(roomNumber) )
         raise "noPasswordPlayRoomNumber"
       end
+    end
+
+    def isSameViewState(viewStates, preViewStateInfo)
+      result = true
+
+      preViewStateInfo ||= {}
+
+      viewStates.each do |key, value|
+        unless( value == preViewStateInfo[key] )
+          result = false
+          break
+        end
+      end
+
+      return result
     end
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -145,6 +145,8 @@ module DodontoF_MySqlKai
       return result
     end
 
+    # ** DodontoF::PlayRoomと違いgetStateは存在しない **
+
   private
 
     def checkCreatePlayRoomPassword(password)

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -335,7 +335,7 @@ COMMAND_END
 
         case resultText
         when "OK"
-          @server.removePlayRoomData(roomNumber)
+          removePlayRoomData(roomNumber)
           deletedRoomNumbers << roomNumber
         when "password"
           passwordRoomNumbers << roomNumber
@@ -355,6 +355,22 @@ COMMAND_END
       @logger.debug(result, 'result')
 
       return result
+    end
+
+    def removePlayRoomData(roomNumber)
+      removeLocalImageTags(roomNumber)
+      @saveDirInfo.removeSaveDir(roomNumber)
+      removeLocalSpaceDir(roomNumber)
+    end
+
+    def removeLocalImageTags(roomNumber)
+      tagInfos = @saveDirInfo.getImageTags(roomNumber)
+      @saveDirInfo.deleteImages(tagInfos.keys)
+    end
+
+    def removeLocalSpaceDir(roomNumber)
+      dir = @server.getRoomLocalSpaceDirNameByRoomNo(roomNumber)
+      DodontoF::Utils.rmdir(dir)
     end
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -166,7 +166,7 @@ module DodontoF_MySqlKai
         timeString = "#{timeStamp.strftime('%Y/%m/%d %H:%M:%S')}"
       end
 
-      loginUsers = @server.getLoginUserNames(roomNo)
+      loginUsers = getLoginUserNames(roomNo)
 
       playRoomState['passwordLockState'] = passwordLockState
       playRoomState['playRoomName'] = playRoomName
@@ -379,7 +379,7 @@ COMMAND_END
       @logger.debug(roomNumberRange, "checkRemovePlayRoom roomNumberRange")
 
       unless( ignoreLoginUser )
-        userNames = @server.getLoginUserNames(roomNumber)
+        userNames = getLoginUserNames(roomNumber)
         userCount = userNames.size
         @logger.debug(userCount, "checkRemovePlayRoom userCount");
 
@@ -426,6 +426,27 @@ COMMAND_END
       end
 
       return "OK"
+    end
+
+    # アクセス中のユーザ名をすべて取得する
+    # 単純に使えるプロパティメソッドなのでpublicにするべきかもしれないが
+    # いったん利用者がないことを考えてprivateにしている
+    #
+    # 実装がDodontoF::PlayRoomとまったく異なるので注意
+    def getLoginUserNames(roomNo)
+      userNames = []
+
+      unless( @server.existRoom?(roomNo) )
+        return userNames
+      end
+
+      @server.deleteUserInfo(roomNo)
+
+      users = @server.getAllUsersData(roomNo)
+      userNames = users.collect{|i| i['userNames']}
+
+      @logger.debug(userNames, "getLoginUserNames userNames")
+      return userNames
     end
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -90,13 +90,12 @@ module DodontoF_MySqlKai
       return result
     end
 
-    def change()
+    def change(params)
       @logger.debug("changePlayRoom begin")
 
       resultText = "OK"
 
       begin
-        params = @server.getParamsFromRequestData()
         @logger.debug(params, "params")
 
         playRoomPassword = params['playRoomPassword']

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -187,7 +187,7 @@ module DodontoF_MySqlKai
 
       adminPassword = params["adminPassword"]
       @logger.debug(adminPassword, "removePlayRoom() adminPassword")
-      if( @server.isMentenanceMode(adminPassword) )
+      if( isMentenanceMode(adminPassword) )
         password = nil
       end
 
@@ -231,7 +231,7 @@ module DodontoF_MySqlKai
       end
 
       adminPassword = params["adminPassword"]
-      if( @server.isMentenanceMode(adminPassword) )
+      if( isMentenanceMode(adminPassword) )
         isPasswordLocked = false
         isWelcomeMessageOn = false
         isMentenanceModeOn = true
@@ -571,6 +571,11 @@ COMMAND_END
       playRoomName = saveData['playRoomName']
       playRoomName ||= "プレイルームNo.#{index}"
       return playRoomName
+    end
+
+    def isMentenanceMode(adminPassword)
+      return false if( $mentenanceModePassword.nil? )
+      return ( adminPassword == $mentenanceModePassword )
     end
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -196,7 +196,7 @@ module DodontoF_MySqlKai
 
     def removeOlds()
       roomNumberRange = (0 .. $saveDataMaxCount)
-      accessTimes = @server.getSaveDataLastAccessTimes( roomNumberRange )
+      accessTimes = getSaveDataLastAccessTimes( roomNumberRange )
       result = removeOldRoomFromAccessTimes(accessTimes)
       return result
     end
@@ -398,7 +398,7 @@ COMMAND_END
         return "unremovablePlayRoomNumber"
       end
 
-      lastAccessTimes = @server.getSaveDataLastAccessTimes( roomNumberRange )
+      lastAccessTimes = getSaveDataLastAccessTimes( roomNumberRange )
       lastAccessTime = lastAccessTimes[roomNumber]
       # DodontoF::PlayRoomでは、ここで
       # lastAccessTime ||= 0
@@ -464,6 +464,24 @@ COMMAND_END
       matched = DodontoF::Utils.isPasswordMatch?(password, changedPassword)
 
       return matched
+    end
+
+    def getSaveDataLastAccessTimes( roomNumberRange )
+      @logger.debug(roomNumberRange, "getSaveDataLastAccessTimes roomNumberRange")
+
+      result = {}
+
+      roomNumberRange.each do |roomNo|
+        # TODO: これ多分ネクストキーロックが効いて酷いのでは…。=でよさそうなので直す
+        where = {"roomNo >= ? " => roomNo }
+        time = @server.getRoomTimeStamp(where)
+
+        result[roomNo] = time
+      end
+
+      @logger.debug(result, "getSaveDataLastAccessTimes result")
+
+      return result
     end
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -9,13 +9,12 @@ module DodontoF_MySqlKai
       @saveDirInfo = saveDirInfo
     end
 
-    def create
+    def create(params)
       @logger.debug('createPlayRoom begin')
 
       resultText = "OK"
       playRoomIndex = -1
       begin
-        params = @server.getParamsFromRequestData()
         @logger.debug(params, "params")
 
         @server.checkCreatePlayRoomPassword(params['createPassword'])

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -272,5 +272,7 @@ COMMAND_END
       viewStates['key'] = Time.now.to_f.to_s
       saveData['viewStateInfo'] = viewStates
     end
+
+    # ** DodontoF::PlayRoomと違って、getSaveDataLastAccessTimeの依存性がまだ外に出ているので後回しにした **
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -147,6 +147,37 @@ module DodontoF_MySqlKai
 
     # ** DodontoF::PlayRoomと違いgetStateは存在しない **
 
+    # DodontoF::PlayRoomと違い
+    # 1. getPlayRoomStateLocalが呼び出し可能点になっている
+    # 2. getPlayRoomStateLocalの引数の個数からして異なるし実装も全体的に違う
+    # という点に注意
+    def getPlayRoomStateLocal(roomNo, playRoomState, playRoomData)
+      return playRoomState if( playRoomData.nil? or playRoomData.empty? )
+
+      playRoomName = @server.getPlayRoomName(playRoomData, roomNo)
+      passwordLockState = (not playRoomData['playRoomChangedPassword'].nil?)
+      canVisit = playRoomData['canVisit']
+      gameType = playRoomData['gameType']
+
+      timeStamp = @server.getRoomTimeStamp()
+
+      timeString = ""
+      unless( timeStamp.nil? )
+        timeString = "#{timeStamp.strftime('%Y/%m/%d %H:%M:%S')}"
+      end
+
+      loginUsers = @server.getLoginUserNames(roomNo)
+
+      playRoomState['passwordLockState'] = passwordLockState
+      playRoomState['playRoomName'] = playRoomName
+      playRoomState['lastUpdateTime'] = timeString
+      playRoomState['canVisit'] = canVisit
+      playRoomState['gameType'] = gameType
+      playRoomState['loginUsers'] = loginUsers
+
+      return playRoomState
+    end
+
   private
 
     def checkCreatePlayRoomPassword(password)

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -39,7 +39,7 @@ module DodontoF_MySqlKai
         @logger.debug(playRoomIndex, 'playRoomIndex')
 
         @server.initSaveFiles(playRoomIndex)
-        @server.checkSetPassword(playRoomPassword, playRoomIndex)
+        checkSetPassword(playRoomPassword, playRoomIndex)
 
         @logger.debug("@saveDirInfo.removeSaveDir(playRoomIndex) Begin")
         # DodontoF::PlayRoomとの違い(@server, @saveDirInfo)に注意
@@ -99,7 +99,7 @@ module DodontoF_MySqlKai
         @logger.debug(params, "params")
 
         playRoomPassword = params['playRoomPassword']
-        @server.checkSetPassword(playRoomPassword)
+        checkSetPassword(playRoomPassword)
 
         playRoomChangedPassword = @server.getChangedPassword(playRoomPassword)
         @logger.debug('playRoomPassword is get')
@@ -206,6 +206,18 @@ COMMAND_END
       }
 
       @server.sendChatMessageByChatData(chatData)
+    end
+
+    def checkSetPassword(playRoomPassword, roomNumber = nil)
+      return if( playRoomPassword.empty? )
+
+      if( roomNumber.nil? )
+        roomNumber = @saveDirInfo.getSaveDataDirIndex
+      end
+
+      if( $noPasswordPlayRoomNumbers.include?(roomNumber) )
+        raise "noPasswordPlayRoomNumber"
+      end
     end
   end
 end

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -461,7 +461,7 @@ COMMAND_END
 
       saveData = @server.getPlayRoomData()
       changedPassword = saveData['playRoomChangedPassword']
-      matched = @server.isPasswordMatch?(password, changedPassword)
+      matched = DodontoF::Utils.isPasswordMatch?(password, changedPassword)
 
       return matched
     end

--- a/test_ruby/dodontof/test_DodontoFServer.rb
+++ b/test_ruby/dodontof/test_DodontoFServer.rb
@@ -51,7 +51,7 @@ class DodontoFServerTest < Test::Unit::TestCase
   end
 
   # 'getPlayRoomStates' => :hasReturn,
-  def test_getPlayRoomState
+  def test_getPlayRoomStates
     params = {
       'cmd' => 'getPlayRoomStates',
       'params' => {


### PR DESCRIPTION
# これなに？

可読性と今後の追加リファクタリングの展開に向けた部分リファクタリングです。
前回までに作ったテストを生かして実際にPlayRoomの概念を
クラスとしてDodontoFServer(MySqlKai)から分離し、抽出しました。

ここでは完全な分離は目標にせず、
必要があればDodontoFServerのインスタンス(`@server`)への
関数呼び出しをPlayRoom側からは行っています。

(ただし`@server`で呼び出しているけれど、DodontoFServer側で呼び出されている場所がないメソッドは
PlayRoom側にDodontoFServer側からメソッドを引っ張って持って来ていますので
最終的には`@server`を使ったへの呼び出しは数個のメソッドのみになりました。)

またPlayRoomの各メソッドは、陽にその内側に閉じたものか、
DodontoFServerのほかのメソッドから呼ばれなければならないものなのか、
を検索でひっかけて抽出しpublic, privateの境界を定めて分離しています。

これらの結果PlayRoomに関するメソッドのうち、
「実際にDodontoFServer(MySqlKai)のほかの部分から呼ばれうるメソッドは何か」
という知識がpublicインタフェイスの部分のメソッドだけになったので
今後は「そのコードの変更はPlayRoomの状態に、影響がある・ない」ということが捉えやすくなったはずです。

また単純に600行程度のコードをDodontoFServerから別枠として分離できたという事でもあります。

-------

ちなみにこの後としては、DodontoFServerのPlayRoomと
DodontoFServerKaiのPlayRoomの共通部分を抽象クラスに切り出すとかそういう方針でいくか
他の概念(たとえばImageとか、Userとか。)をこれも切り出すとかですかね。と思ってます。