### PR TITLE
CGIのGETリクエストでエラーが起こる問題を修正する

### DIFF
--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -204,31 +204,50 @@ class DodontoFServer
     end
     
   end
-  def getRawCGIValue
+
+  # CGI のクエリ文字列から指定したキーの値を取得する
+  # @param [String] key キー
+  # @return [String] キーが存在する場合
+  # @return [nil] キーが存在しない場合
+  def getRawCGIValue(key)
     @cgi ||= CGI.new
-    @cgi.params[key].first
-  end
-  
-  def getRequestData(key)
-    @logger.debug(key, "getRequestData key")
-    
-    value = @cgiParams[key]
-    # @logger.debug(@cgiParams, "@cgiParams")
-    # @logger.debug(value, "getRequestData value")
-    
-    if( value.nil? )
-      if( @isWebIf )
-        value = getRawCGIValue
-      end
+
+    # CGI#params[] では配列または nil が返るため、キーが含まれているか
+    # どうかのチェックが必要
+    if @cgi.params.key?(key)
+      @cgi.params[key].first
+    else
+      nil
     end
-    
-    
-    # @logger.debug(value, "getRequestData result")
-    
-    return value
   end
 
-  
+  # 指定したキーの値を返す
+  #
+  # Web インターフェースの場合はクエリ文字列からの値の取得を試みる
+  # @param [String] key キー
+  # @return [Object]
+  # @return [nil]
+  def getRequestData(key)
+    @logger.debug(key, "getRequestData key")
+
+    valueFromCgiParams = @cgiParams[key]
+    @logger.debug(@cgiParams, "@cgiParams")
+    @logger.debug(valueFromCgiParams, "getRequestData valueFromCgiParams")
+
+    unless valueFromCgiParams.nil?
+      @logger.debug(valueFromCgiParams, "getRequestData result cgiParams")
+      return valueFromCgiParams
+    end
+
+    return nil unless @isWebIf
+
+    # Web インターフェースの場合
+    valueWebIf = getRawCGIValue(key)
+
+    @logger.debug(valueWebIf, "getRequestData result WebIF")
+    return valueWebIf
+  end
+
   attr :isAddMarker
   attr :jsonpCallBack
   attr :isJsonResult

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -205,31 +205,49 @@ class DodontoFServer_MySqlKai
     @saveDirInfo.init(roomNumber, $saveDataMaxCount, $SAVE_DATA_DIR)
   end
 
-  def getRawCGIValue
+  # CGI のクエリ文字列から指定したキーの値を取得する
+  # @param [String] key キー
+  # @return [String] キーが存在する場合
+  # @return [nil] キーが存在しない場合
+  def getRawCGIValue(key)
     @cgi ||= CGI.new
-    @cgi.params[key].first
+
+    # CGI#params[] では配列または nil が返るため、キーが含まれているか
+    # どうかのチェックが必要
+    if @cgi.params.key?(key)
+      @cgi.params[key].first
+    else
+      nil
+    end
   end
-  
+
+  # 指定したキーの値を返す
+  #
+  # Web インターフェースの場合はクエリ文字列からの値の取得を試みる
+  # @param [String] key キー
+  # @return [Object]
+  # @return [nil]
   def getRequestData(key)
     @logger.debug(key, "getRequestData key")
-    
-    value = @cgiParams[key]
-    # @logger.debug(@cgiParams, "@cgiParams")
-    # @logger.debug(value, "getRequestData value")
-    
-    if( value.nil? )
-      if( @isWebIf )
-        value = getRawCGIValue
-      end
+
+    valueFromCgiParams = @cgiParams[key]
+    @logger.debug(@cgiParams, "@cgiParams")
+    @logger.debug(valueFromCgiParams, "getRequestData valueFromCgiParams")
+
+    unless valueFromCgiParams.nil?
+      @logger.debug(valueFromCgiParams, "getRequestData result cgiParams")
+      return valueFromCgiParams
     end
-    
-    
-    # @logger.debug(value, "getRequestData result")
-    
-    return value
+
+    return nil unless @isWebIf
+
+    # Web インターフェースの場合
+    valueWebIf = getRawCGIValue(key)
+
+    @logger.debug(valueWebIf, "getRequestData result WebIF")
+    return valueWebIf
   end
-  
-  
+
   attr :isAddMarker
   attr :jsonpCallBack
   attr :isJsonResult

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+#--*-coding:utf-8-*--
+
 require "rake/testtask"
 
 task :default => :test

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,34 @@ require "rake/testtask"
 
 task :default => :test
 
-Rake::TestTask.new(:test) do |t|
-  t.test_files = FileList['test_ruby/**/test*.rb']
+Rake::TestTask.new(:test_libs) do |t|
+  t.test_files = ['test_ruby/test*.rb', 'test_ruby/dodontof/**/test*.rb']
+end
+
+Rake::TestTask.new(:test_cgi) do |t|
+  t.test_files = ['test_ruby/cgi/test*.rb']
+end
+
+desc 'すべてのテストを行う'
+task :test do
+  failures = []
+
+  puts('[ライブラリのテスト]')
+  begin
+    Rake::Task['test_libs'].execute
+  rescue
+    failures << 'ライブラリ'
+  end
+
+  puts
+  puts('[CGI のテスト]')
+  begin
+    Rake::Task['test_cgi'].execute
+  rescue
+    failures << 'CGI'
+  end
+
+  unless failures.empty?
+    raise "テスト失敗: #{failures.join(', ')}"
+  end
 end

--- a/test_ruby/cgi/test_cgi_request.rb
+++ b/test_ruby/cgi/test_cgi_request.rb
@@ -23,6 +23,20 @@ class CGIRequestTest < Test::Unit::TestCase
     @prevStdin = $stdin
     # 標準出力の記録用
     @prevStdout = $stdout
+
+    # ディレクトリの準備
+    FileUtils.mkdir_p($SAVE_DATA_DIR)
+    FileUtils.mkdir_p($imageUploadDir)
+    FileUtils.mkdir_p($replayDataUploadDir)
+    FileUtils.mkdir_p($saveDataTempDir)
+    FileUtils.mkdir_p($fileUploadDir)
+
+    # セーブデータの準備
+    saveDataDir = File.join($SAVE_DATA_DIR, 'saveData')
+    FileUtils.cp_r('saveData', saveDataDir)
+
+    # ログイン人数カウントの準備
+    File.write(File.join(saveDataDir, 'loginCount.txt'), '0')
   end
 
   def teardown
@@ -30,6 +44,9 @@ class CGIRequestTest < Test::Unit::TestCase
     ENV.update(@environ)
     $stdin = @prevStdin
     $stdout = @prevStdout
+
+    # ファイルの削除
+    FileUtils.rm_r('.temp')
   end
 
   # コマンドを指定せずに GET した場合

--- a/test_ruby/cgi/test_cgi_request.rb
+++ b/test_ruby/cgi/test_cgi_request.rb
@@ -66,6 +66,7 @@ class CGIRequestTest < Test::Unit::TestCase
     assert_match(pattern, out.string.toutf8)
   end
 
+  # GET で WebIF の getBusyInfo を呼び出した場合
   def test_CGI_GET_webif_getBusyInfo
     updateEnv('REQUEST_METHOD' => 'GET',
               'QUERY_STRING' => 'webif=getBusyInfo')
@@ -82,6 +83,7 @@ class CGIRequestTest < Test::Unit::TestCase
     assert_equal(true, response.kind_of?(Hash))
   end
 
+  # POST で getPlayRoomStates を呼び出した場合
   def test_CGI_POST_getPlayRoomStates
     # メッセージデータの準備
     paramObject = {

--- a/test_ruby/cgi/test_cgi_request.rb
+++ b/test_ruby/cgi/test_cgi_request.rb
@@ -1,0 +1,119 @@
+#--*-coding:utf-8-*--
+
+$LOAD_PATH.unshift(File.expand_path('../..', File.dirname(__FILE__)))
+$LOAD_PATH.unshift(File.expand_path( '..', File.dirname(__FILE__)))
+
+require 'stringio'
+require 'test_helper'
+
+require 'test/unit'
+
+# テスト用のコンフィグファイルをDodontoFServerに読みこませる
+$isTestMode = true
+require 'DodontoFServer.rb'
+
+require 'msgpack/msgpackPure'
+require 'json/jsonParser'
+
+class CGIRequestTest < Test::Unit::TestCase
+  def setup
+    # 環境変数の記録用
+    @environ = {}
+    # 標準入力の記録用
+    @prevStdin = $stdin
+    # 標準出力の記録用
+    @prevStdout = $stdout
+  end
+
+  def teardown
+    # 環境変数、標準入力、標準出力を元に戻す
+    ENV.update(@environ)
+    $stdin = @prevStdin
+    $stdout = @prevStdout
+  end
+
+  # コマンドを指定せずに GET した場合
+  def test_CGI_GET_noCommand
+    updateEnv('REQUEST_METHOD' => 'GET',
+              'QUERY_STRING' => '')
+
+    out = StringIO.new
+    changeStdout(out)
+
+    executeDodontoServerCgi
+
+    pattern = /^#{Regexp.escape('["「どどんとふ」の動作環境は正常に起動しています。"]')}$/
+    assert_match(pattern, out.string)
+  end
+
+  def test_CGI_GET_webif_getBusyInfo
+    updateEnv('REQUEST_METHOD' => 'GET',
+              'QUERY_STRING' => 'webif=getBusyInfo')
+
+    out = StringIO.new
+    changeStdout(out)
+
+    executeDodontoServerCgi
+
+    assert_match(/^\{"loginCount":\d+,"maxLoginCount":\d+,"version":".+?","result":"OK"\}$/,
+                 out.string)
+  end
+
+  def test_CGI_POST_getPlayRoomStates
+    # メッセージデータの準備
+    paramObject = {
+      'cmd' => 'getPlayRoomStates',
+      'params' => {
+        'minRoom' => 0,
+        'maxRoom' => 3,
+      }
+    }
+    messagePackedData = MessagePackPure.pack(paramObject)
+
+    # 環境変数の更新
+    updateEnv('REQUEST_METHOD' => 'POST',
+              'CONTENT_TYPE' => 'application/x-msgpack',
+              'CONTENT_LENGTH' => messagePackedData.bytesize.to_s)
+
+    # 標準入力、標準出力の変更
+    inIo = StringIO.new(messagePackedData)
+    changeStdin(inIo)
+
+    out = StringIO.new
+    changeStdout(out)
+
+    # サーバー実行
+    executeDodontoServerCgi
+
+    # 出力の変換
+    out_tail = out.string.lines.last.chomp
+    response = JsonParser.new.parse(out_tail)
+
+    assert_equal(true, response.kind_of?(Hash))
+  end
+
+  private
+
+  # 標準入力を記録してから変更する
+  def changeStdin(stdin)
+    @prevStdin = $stdin
+    $stdin = stdin
+  end
+
+  # 標準出力を記録してから変更する
+  def changeStdout(stdout)
+    @prevStdout = $stdout
+    $stdout = stdout
+  end
+
+  # 環境変数を記録してから更新する
+  #
+  # Ruby の CGI ライブラリのテストより流用
+  # @see https://github.com/ruby/ruby/blob/3e92b635fb5422207b7bbdc924e292e51e21f040/test/cgi/update_env.rb
+  def updateEnv(environ)
+    environ.each do |key, val|
+      @environ[key] = ENV[key] unless @environ.key?(key)
+      ENV[key] = val
+    end
+  end
+end

--- a/test_ruby/config_test.rb
+++ b/test_ruby/config_test.rb
@@ -8,3 +8,6 @@ $imageUploadDir = ".temp/imageUploadSpace"
 $replayDataUploadDir = ".temp/replayDataUploadSpace"
 $saveDataTempDir = ".temp/saveDataTempSpace"
 $fileUploadDir = ".temp/fileUploadSpace"
+
+# 環境に依存しないようにするため gem の msgpack は使わない
+$isMessagePackInstalled = false

--- a/test_ruby/server_test_impl.rb
+++ b/test_ruby/server_test_impl.rb
@@ -22,7 +22,11 @@ module DodontoFServerTestImpl
   def getDodontoFServerForTest
     @dodontof_server_for_Test ||= Class.new(getTargetDodontoFServer) do
       attr_accessor :mock_raw_cgi_value
-      def getRawCGIValue; @mock_raw_cgi_value; end
+
+      def getRawCGIValue(key)
+        @mock_raw_cgi_value ||= {}
+        @mock_raw_cgi_value[key]
+      end
     end
   end
 

--- a/test_ruby/test/unit/assertions/assert_have_keys.rb
+++ b/test_ruby/test/unit/assertions/assert_have_keys.rb
@@ -1,0 +1,12 @@
+#--*-coding:utf-8-*--
+
+require 'test/unit'
+
+module Test::Unit::Assertions
+  # +hash+ のキーに +keys+ がすべて存在することを表明する
+  def assert_have_keys(hash, *keys)
+    keys.each do |k|
+      assert_equal(true, hash.has_key?(k))
+    end
+  end
+end


### PR DESCRIPTION
リファクタリングに伴いCGIのGETリクエストでエラーが起こるようになった問題を修正しました。

これは 4ac7dca でサーバーに導入された以下の [getRawCGIValue メソッド](https://github.com/torgtaitai/DodontoF/commit/4ac7dca63d99846aef983e5925a9144d73a5528f#diff-3e1c8b69063e3955e681f24976bb0cdcR203) が原因です。引数で `key` を取っていないため、`undefined local variable or method` というメッセージで NameError が起きます。

> ```ruby
> def getRawCGIValue
>   @cgi ||= CGI.new
>   @cgi.params[key].first
> end
> ```

修正に伴い、CGIリクエストのテストも追加しました。こちらは最近追加されたサーバーのテストと干渉するため、Rakefileに別タスクとして実行タスクを定義しています。Travis CI等での自動テストが行えるよう、`rake` コマンドではライブラリのテストとCGIリクエストのテストを順番に実行するよう設定しました。