### PR TITLE
.gitignore を復活させる

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.temp
+/test_log.txt


### PR DESCRIPTION
v1.48.05 のコミット 426d0f6 で /.gitignore が削除されていますが、このファイルは git でコミットする際、テスト失敗時に残った一時ディレクトリを誤って追加しないようにするために設置されたと思われます。あった方がコミット時のミスが減ると思いますので、復活させてみました。