### PR TITLE
MessagePack ライブラリ読み込み処理を共通化する

### DIFF
--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -59,27 +59,7 @@ end
 require "FileLock.rb"
 require "saveDirInfo.rb"
 
-
-$dodontofWarning = nil
-
-if( $isMessagePackInstalled )
-  # gem install msgpack してる場合はこちら。
-  begin
-    require 'rubygems'
-    require 'msgpack'
-  rescue Exception
-    $dodontofWarning = {"key" => "youNeedInstallMsgPack"}
-  end
-else
-  if( RUBY_VERSION >= '1.9.0' )
-    # msgpack のRuby1.9用
-    require 'msgpack/msgpack19'
-  else
-    # MessagePackPure バージョン
-    require 'msgpack/msgpackPure'
-  end
-end
-
+require 'dodontof/msgpack_loader'
 
 
 $saveFileNames = File.join($saveDataTempDir, 'saveFileNames.json');
@@ -5659,10 +5639,12 @@ class DodontoFServer
   
   def getResponse
     response =
-      if $dodontofWarning.nil?
-        analyzeCommand
+      if DodontoF::MsgpackLoader.failed?
+        {
+          'warning' => { 'key' => 'youNeedInstallMsgPack' }
+        }
       else
-        { 'warning' => $dodontofWarning }
+        analyzeCommand
       end
 
     if isJsonResult

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -61,27 +61,7 @@ end
 require "FileLock.rb"
 require "saveDirInfoMysql.rb"
 
-
-$dodontofWarning = nil
-
-if( $isMessagePackInstalled )
-  # gem install msgpack してる場合はこちら。
-  begin
-    require 'rubygems'
-    require 'msgpack'
-  rescue Exception
-    $dodontofWarning = {"key" => "youNeedInstallMsgPack"}
-  end
-else
-  if( RUBY_VERSION >= '1.9.0' )
-    # msgpack のRuby1.9用
-    require 'msgpack/msgpack19'
-  else
-    # MessagePackPure バージョン
-    require 'msgpack/msgpackPure'
-  end
-end
-
+require 'dodontof/msgpack_loader'
 
 
 $saveFileNames = File.join($saveDataTempDir, 'saveFileNames.json');
@@ -5826,10 +5806,12 @@ SQL_TEXT
   
   def getResponse
     response =
-      if $dodontofWarning.nil?
-        analyzeCommand
+      if DodontoF::MsgpackLoader.failed?
+        {
+          'warning' => { 'key' => 'youNeedInstallMsgPack' }
+        }
       else
-        { 'warning' => $dodontofWarning }
+        analyzeCommand
       end
 
     if isJsonResult

--- a/src_ruby/dodontof/msgpack_loader.rb
+++ b/src_ruby/dodontof/msgpack_loader.rb
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+lib_dir = File.expand_path('..', File.dirname(__FILE__))
+$LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
+
+module DodontoF
+  # MessagePack ライブラリの読み込み処理
+  module MsgpackLoader
+    # MessagePack ライブラリの読み込みに失敗したかどうか
+    @@failed = false
+
+    module_function
+    # MessagePack ライブラリを読み込む
+    # @return [true] MessagePack ライブラリの読み込みが行われた場合
+    # @return [false] MessagePack ライブラリの読み込みが行われなかった場合
+    def load
+      # 既に読み込まれていたら何もしない
+      return false if defined?(::MessagePack)
+
+      begin
+        if $isMessagePackInstalled
+          # gem install msgpack してる場合はこちら
+          require 'rubygems'
+          require 'msgpack'
+        else
+          if RUBY_VERSION >= '1.9.0'
+            # msgpack の Ruby 1.9 用
+            require 'msgpack/msgpack19'
+          else
+            # MessagePackPure バージョン
+            require 'msgpack/msgpackPure'
+          end
+        end
+      rescue LoadError
+        # 読み込み失敗
+        @@failed = true
+        return false
+      end
+
+      true
+    end
+
+    # MessagePack ライブラリの読み込みに失敗したかどうかを返す
+    # @return [Boolean] MessagePack ライブラリの読み込みに失敗したかどうか
+    def failed?
+      @@failed
+    end
+  end
+end
+
+DodontoF::MsgpackLoader.load


### PR DESCRIPTION
DodontoFServer.rbおよびDodontoFServerMySqlKai.rbに同じコードとして存在していたMessagePackライブラリ読み込み処理を新しいモジュール `DodontoF::MsgpackLoader` にまとめ、共通化しました。また、MessagePackライブラリ読み込み失敗以外で使われていなかったグローバル変数 `$dodontofWarning` を除きました。