### PR TITLE
バージョン関連のグローバル変数をモジュール定数化する

### DIFF
--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -9,15 +9,6 @@ $LOAD_PATH << File.dirname(__FILE__) # require_relative対策
 #クライアント通知されたJsonデータからセーブデータ(.jsonテキスト)を読み出し・書き出しするのが主な作業。
 #変更可能な設定は config.rb にまとめているため、環境設定のためにこのファイルを変更する必要は基本的には無いです。
 
-
-#サーバCGIとクライアントFlashのバージョン一致確認用
-$versionOnly = "Ver.1.48.07"
-$versionDate = "2016/05/31"
-$version = "#{$versionOnly}(#{$versionDate})"
-
-
-
-
 if( RUBY_VERSION >= '1.9.0' )
   Encoding.default_external = 'utf-8'
 else
@@ -30,6 +21,7 @@ require 'stringio'
 require 'uri'
 require 'fileutils'
 
+require 'dodontof/version'
 require 'dodontof/logger'
 require 'dodontof/utils'
 require 'dodontof/dice_adapter'
@@ -1194,7 +1186,7 @@ class DodontoFServer
     jsonData = {
       "loginCount" => File.readlines($loginCountFileFullPath).join.to_i,
       "maxLoginCount" => $aboutMaxLoginCount,
-      "version" => $version,
+      "version" => DodontoF::FULL_VERSION_STRING,
       "result" => 'OK',
     }
     
@@ -2042,7 +2034,7 @@ class DodontoFServer
       "refreshTimeout" => $refreshTimeout,
       "refreshInterval" => getRefreshInterval(),
       "isCommet" => $isCommet,
-      "version" => $version,
+      "version" => DodontoF::FULL_VERSION_STRING,
       "playRoomMaxNumber" => ($saveDataMaxCount - 1),
       "warning" => getLoginWarning(),
       "playRoomGetRangeMax" => $playRoomGetRangeMax,

--- a/DodontoFServerMySql.rb
+++ b/DodontoFServerMySql.rb
@@ -14,9 +14,6 @@ unless $isTestMode
   $SAVE_DATA_DIR = '.'
 end
 
-#サーバCGIとクライアントFlashのバージョン一致確認用
-$version = "Ver.1.48.07(2016/05/31)"
-
 class SaveDataManagerOnMySql
   include DodontoF::Utils
 

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -10,15 +10,6 @@ $LOAD_PATH << File.dirname(__FILE__) # require_relative対策
 #DB(MySQL)から各種データを読み出し・書き出しするのが主な作業。
 #変更可能な設定は config.rb にまとめているため、環境設定のためにこのファイルを変更する必要は基本的には無いです。
 
-
-#サーバCGIとクライアントFlashのバージョン一致確認用
-$versionOnly = "Ver.1.48.07"
-$versionDate = "2016/05/31"
-$version = "#{$versionOnly}(#{$versionDate})"
-
-
-
-
 if( RUBY_VERSION >= '1.9.0' )
   Encoding.default_external = 'utf-8'
 else
@@ -34,6 +25,7 @@ require 'json/jsonParser'
 
 require 'mysql'
 
+require 'dodontof/version'
 require 'dodontof/logger'
 require 'dodontof/utils'
 require 'dodontof/dice_adapter'
@@ -1426,7 +1418,7 @@ SQL_TEXT
     jsonData = {
       "loginCount" => getLoginCount(),
       "maxLoginCount" => $aboutMaxLoginCount,
-      "version" => $version,
+      "version" => DodontoF::FULL_VERSION_STRING,
       "result" => 'OK',
     }
     
@@ -2288,7 +2280,7 @@ SQL_TEXT
       "refreshTimeout" => $refreshTimeout,
       "refreshInterval" => getRefreshInterval(),
       "isCommet" => $isCommet,
-      "version" => $version,
+      "version" => DodontoF::FULL_VERSION_STRING,
       "playRoomMaxNumber" => ($saveDataMaxCount - 1),
       "warning" => getLoginWarning(),
       "playRoomGetRangeMax" => $playRoomGetRangeMax,

--- a/src_ruby/dodontof/version.rb
+++ b/src_ruby/dodontof/version.rb
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+module DodontoF
+  # バージョン
+  VERSION = '1.48.07'
+  # リリース日
+  RELEASE_DATE = '2016/05/31'
+
+  # バージョンとリリース日を含む文字列
+  #
+  # サーバ CGI とクライアント Flash のバージョン一致確認用
+  FULL_VERSION_STRING = "Ver.#{VERSION}(#{RELEASE_DATE})"
+end


### PR DESCRIPTION
サーバーについて、グローバル変数で指定していたバージョンを以下のようにモジュール定数化しました。これらは src_ruby/dodontof/version.rb にあります。

* `$versionOnly` -> `DodontoF::VERSION`
* `$versionDate` -> `DodontoF::RELEASE_DATE`
* `$version` -> `DodontoF::FULL_VERSION_STRING`

このようにすることで、各サーバー（ファイル、MySql、MySqlKai）のバージョンを必ず統一することができます。また、多用しない方がよいグローバル変数を減らすことができます。