### PR TITLE
SWF 作成用の Rake タスクを追加する

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,3 +35,22 @@ task :test do
     raise "テスト失敗: #{failures.join(', ')}"
   end
 end
+
+desc 'SWF ファイルを作成する'
+task :swf do
+  mxmlc = 'mxmlc'
+  options = [
+    '-target-player=10.0.12',
+    '-define=TEST::isTest,false',
+    '-define=COMPILE::isReplayer,false',
+    '-define=COMPILE::isMySql,false',
+    '-include-libraries+=./corelib/bin/corelib.swc',
+    '-o ../DodontoF.swf'
+  ]
+  input = 'DodontoF.mxml'
+  command = ([mxmlc] + options + [input]).join(' ')
+
+  Dir.chdir('src_actionScript') do
+    sh(command)
+  end
+end


### PR DESCRIPTION
Rubyに標準添付されているビルドツールrakeを使ってSWFのコンパイルを簡単に行えるようにするタスクを追加しました。

マニュアルに記載されている

```
mxmlc.exe -target-player=10.0.12 -define=TEST::isTest,false -define=COMPILE::isReplayer,false -define=COMPILE::isMySql,false -include-libraries+=./corelib/bin/corelib.swc -o ../DodontoF.swf DodontoF.mxml
```

というコマンドを、以下の短い1行で実行できるようにするものです。

```
rake swf
```

rakeの仕様により、どどんとふの開発ディレクトリ以下ならばサブディレクトリに入っていても以上のコマンドでコンパイルを行うことができます。

# 動作確認
Unix系OS（OSX、Linux（Ubuntu））で実行できることを確認しましたが、Windows環境が手元になく動作確認ができていません。mxmlcコマンドの拡張子（.exe）を除いているため、その影響で動作しなくなっていないか確認していただけないでしょうか。