### PR TITLE
プレイルーム名に「削除可」を含めることを禁止する機能を追加する

### DIFF
--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2053,6 +2053,7 @@ class DodontoFServer
       'canUseExternalImageModeOn' => $canUseExternalImageModeOn,
       'characterInfoToolTipMax' => [$characterInfoToolTipMaxWidth, $characterInfoToolTipMaxHeight],
       'isAskRemoveRoomWhenLogout' => $isAskRemoveRoomWhenLogout,
+      'disallowRenamingPlayRoomAsDeletable' => $disallowRenamingPlayRoomAsDeletable,
     }
     
     @logger.debug(result, "result")

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2298,6 +2298,7 @@ SQL_TEXT
       'languages' => getLanguages(),
       'canUseExternalImageModeOn' => $canUseExternalImageModeOn,
       'characterInfoToolTipMax' => [$characterInfoToolTipMaxWidth, $characterInfoToolTipMaxHeight],
+      'disallowRenamingPlayRoomAsDeletable' => $disallowRenamingPlayRoomAsDeletable,
     }
     
     @logger.debug(result, "result")

--- a/languages/Chinese-Traditional.txt
+++ b/languages/Chinese-Traditional.txt
@@ -676,6 +676,7 @@ magicTimerStartRound = 效果開始回合:
 magicTimerStartInitiative = 效果開始先攻值:
 magicTimerInfo = 其他:
 changePlayRoom = 變更遊戲室內容
+disallowRenamingPlayRoomAsDeletable = You can't include "削除可" (deletable) in the name of a play room in this server. Please delete this play room after the session has been over.
 useExternalImageTips = 許可使用外部圖像的話，指定圖像時可以使用外部網址。未指定本項時若使用外部網址將會顯示×記號。
 canVisitTips = 許可觀戰的話，即使遊戲室有密碼鎖也可以開放觀戰者自由進入。觀戰者只能在對話欄的「觀戰用」分頁發言，名稱會變成「（名稱）＠觀戰」的形式。完全無法進行意外的對話發言，或是對地圖及角色進行操作。
 playRoomNameTips = 未設定遊戲室名稱的場合，認定為被刪除的暫時使用。\n正式使用的場合請輸入正確的名稱。

--- a/languages/English.txt
+++ b/languages/English.txt
@@ -680,6 +680,7 @@ magicTimerStartRound = Start Round:
 magicTimerStartInitiative = Start Initiative:
 magicTimerInfo = Info:
 changePlayRoom = Change Play Room
+disallowRenamingPlayRoomAsDeletable = You can't include "削除可" (deletable) in the name of a play room in this server. Please delete this play room after the session has been over.
 useExternalImageTips = If check, you can use external site image to Image File target. If NOT checked, image change to X mark means no image.
 canVisitTips = If check, anyone can login ignore password. but visitor only can seeing, can NOT move anything, and talk only "for Visitor" Tab. and Name always safixed "@Visitor"
 playRoomNameTips = If you did NOT define play name, it's seemd to "actualy did not used", so anyone delete it.\nIf you want to play, set a good room name.

--- a/languages/Korean.txt
+++ b/languages/Korean.txt
@@ -1,4 +1,4 @@
-﻿# 샘-플-메-세-지-
+# 샘-플-메-세-지-
 # 이 문서는 도돈토후의 한국어 번역입니다
 # 도돈토후 짱 좋아여
 # 님들 roll20만 쓰지마시고 도돈토후 쓰세여...
@@ -678,6 +678,7 @@ magicTimerStartRound = 효과개시 라운드:
 magicTimerStartInitiative = 효과개시 이니셔티브:
 magicTimerInfo = 그 외:
 changePlayRoom = 플레이 룸 변경
+disallowRenamingPlayRoomAsDeletable = You can't include "削除可" (deletable) in the name of a play room in this server. Please delete this play room after the session has been over.
 useExternalImageTips = 외부 이미지를 허가하면 이미지 지정시에 외부 URL를 사용할 수 있게 됩니다. 지정하지 않은 경우는 외부 URL을 이미지에 사용하면 ×마크로 바뀝니다.
 canVisitTips = 관전 가능으로 하면 패스워드가 있어도 관전자라면 로그인 할 수 있게 됩니다. 관전자는 채팅의 「관전용」 탭에서만 발언할 수 있고 이름은 「（이름）＠관전」이 됩니다. 채팅 발언 이외의 맵이나 캐릭터 등의 조작은 할 수 없습니다.
 playRoomNameTips = 플레이 룸 명을 지정하지 않을 경우, 임시 사용으로 간주하고 삭제합니다. \n정식으로 이용할 경우는 올바른 이름을 붙여주세요.

--- a/languages/_Japanese.txt
+++ b/languages/_Japanese.txt
@@ -678,6 +678,7 @@ magicTimerStartRound = 効果開始ラウンド:
 magicTimerStartInitiative = 効果開始イニシアティブ:
 magicTimerInfo = その他:
 changePlayRoom = プレイルーム変更
+disallowRenamingPlayRoomAsDeletable = このサーバーでは、プレイルーム名に「削除可」を含めることを禁止しています。\nセッション終了後は、ログアウト時の確認画面またはログイン画面でこのプレイルームを削除してください。
 useExternalImageTips = 外部画像の許可を行うと画像指定時に外部URLが使用出来るようになります。指定していない場合に外部URLを画像に使用すると×マークに指し換わります。
 canVisitTips = 見学可にすると、パスワード有りでも見学者ならログインできるようになります。見学者はチャットの「見学用」タブでの発言のみが許可され、名前は「（名前）＠見学」になります。チャット発言意外の、マップやキャラ等の操作は一切できません。
 playRoomNameTips = プレイルーム名を設定しない場合、仮使用とみなして削除されます。\n正式に利用する場合には正しく名前をつけましょう。

--- a/src_actionScript/ChangePlayRoomWindow.as
+++ b/src_actionScript/ChangePlayRoomWindow.as
@@ -2,6 +2,7 @@
 
 package {
     import mx.controls.CheckBox;
+    import mx.controls.Alert;
     
     public class ChangePlayRoomWindow extends CreatePlayRoomWindow {
         import mx.managers.PopUpManager;
@@ -60,8 +61,16 @@ package {
                 }
         }
         
-        
+        // プレイルーム情報の変更を実行する
         override protected function execute():void {
+            if (!isValidPlayRoomName(playRoomName.text)) {
+                // プレイルーム名に「削除可」を含めることを許可しない
+                Alert.show(Language.s.disallowRenamingPlayRoomAsDeletable,
+                           Language.s.changePlayRoom,
+                           Alert.OK);
+                return;
+            }
+
             try {
                 var chatChannelNames:Array = getChatChannelNames();
                 
@@ -83,6 +92,16 @@ package {
             
         }
         
+        // 有効なプレイルーム名かどうかを返す
+        private function isValidPlayRoomName(playRoomName:String):Boolean {
+            if (!Config.getInstance().disallowRenamingPlayRoomAsDeletable) {
+                return true;
+            }
+
+            // プレイルーム名に「削除可」を含めることを許可しない場合のみ
+            // チェックを行う
+            return playRoomName.indexOf("削除可") == -1;
+        }
     }
 }
 

--- a/src_actionScript/Config.as
+++ b/src_actionScript/Config.as
@@ -582,5 +582,17 @@ package {
             return isAskRemoveRoomWhenLogoutMode;
         }
         
+        // 部屋の名前に「削除可」を含めることを許可しないかどうか
+        private var _disallowRenamingPlayRoomAsDeletable:Boolean = false;
+
+        // 部屋の名前に「削除可」を含めることを許可しないかどうかの setter
+        public function set disallowRenamingPlayRoomAsDeletable(value:Boolean):void {
+            _disallowRenamingPlayRoomAsDeletable = value;
+        }
+
+        // 部屋の名前に「削除可」を含めることを許可しないかどうかの getter
+        public function get disallowRenamingPlayRoomAsDeletable():Boolean {
+            return _disallowRenamingPlayRoomAsDeletable;
+        }
     }
 }

--- a/src_actionScript/Language.as
+++ b/src_actionScript/Language.as
@@ -767,6 +767,7 @@ package {
             
             // ChangePlayRoomWindow.as
             p.changePlayRoom = "プレイルーム変更";
+            p.disallowRenamingPlayRoomAsDeletable = "このサーバーでは、プレイルーム名に「削除可」を含めることを禁止しています。\nセッション終了後は、ログアウト時の確認画面またはログイン画面でこのプレイルームを削除してください。";
             // CreatePlayRoomWindow.mxml
             p.useExternalImageTips = "外部画像の許可を行うと画像指定時に外部URLが使用出来るようになります。指定していない場合に外部URLを画像に使用すると×マークに指し換わります。";
             p.canVisitTips = "見学可にすると、パスワード有りでも見学者ならログインできるようになります。見学者はチャットの「見学用」タブでの発言のみが許可され、名前は「（名前）＠見学」になります。チャット発言意外の、マップやキャラ等の操作は一切できません。";

--- a/src_actionScript/LoginWindow.mxml
+++ b/src_actionScript/LoginWindow.mxml
@@ -610,7 +610,7 @@
         }
         
         DodontoF_Main.getInstance().setLogoutUrl( jsonData.logoutUrl );
-        isNeedCreatePassword = jsonData.isNeedCreatePassword 
+        isNeedCreatePassword = jsonData.isNeedCreatePassword;
         Config.getInstance().setImageUploadDirInfo(jsonData.imageUploadDirInfo);
         
         playRoomGetRangeMax = jsonData.playRoomGetRangeMax;
@@ -630,7 +630,10 @@
         DodontoF_Main.getInstance().setUniqueId( jsonData.uniqueId);
         DodontoF_Main.getInstance().setCanUseExternalImageModeOn( jsonData.canUseExternalImageModeOn );
         Config.getInstance().setCharacterInfoToolTipMax( jsonData.characterInfoToolTipMax );
+        
+        // プレイルーム削除関連の設定
         Config.getInstance().isAskRemoveRoomWhenLogout = jsonData.isAskRemoveRoomWhenLogout;
+        Config.getInstance().disallowRenamingPlayRoomAsDeletable = jsonData.disallowRenamingPlayRoomAsDeletable;
         
         DrawMapWindow.setLineCountLimit( jsonData.drawLineCountLimit );
         

--- a/src_ruby/config.rb
+++ b/src_ruby/config.rb
@@ -273,6 +273,9 @@ $characterInfoToolTipMaxHeight = -1
 #ログアウト時に他に人がいない場合、部屋の削除を質問するかどうかを設定（true:質問する、false:しない)
 $isAskRemoveRoomWhenLogout = true
 
+# プレイルーム名に「削除可」を含めることを禁止します（true：禁止、false：許可）。
+# セッション終了後のプレイルーム放置対策の機能です。
+$disallowRenamingPlayRoomAsDeletable = false
 
 # src_bcdice/diceBot/ に置いてあるダイスボットを全て一覧に表示するかどうかの指定。
 # false の場合は下記の $diceBotOrder に記載されていないダイスボットは一覧に表示されません。

--- a/test_ruby/test_DodontoFServer.rb
+++ b/test_ruby/test_DodontoFServer.rb
@@ -573,7 +573,8 @@ class DodontoFServerTest < Test::Unit::TestCase
       'languages',
       'canUseExternalImageModeOn',
       'characterInfoToolTipMax',
-      'isAskRemoveRoomWhenLogout'
+      'isAskRemoveRoomWhenLogout',
+      'disallowRenamingPlayRoomAsDeletable'
     )
 
     assert_equal(nil, parsed['warning'])


### PR DESCRIPTION
セッション後のプレイルーム放置対策として、プレイルーム名に「削除可」を含めることを禁止する機能を追加しました。

# サーバー：設定項目の追加
以下の設定項目を src_ruby/config.rb に追加しました。既定では従来同様プレイルーム名に「削除可」を含めることを許可するようにしています。

```ruby
# プレイルーム名に「削除可」を含めることを禁止します（true：禁止、false：許可）。
# セッション終了後のプレイルーム放置対策の機能です。
$disallowRenamingPlayRoomAsDeletable = false
```

# クライアントの変更

## 設定項目の追加への対応
上記の設定を読み込むように src_actionScript/LoginWindow.mxml と src_actionScript/Config.as の処理を追加しました。

## プレイルーム情報変更画面の処理の変更
プレイルーム情報変更画面（src_actionScript/ChangePlayRoomWindow.as）において、上記の設定によりプレイルーム名が有効か判定する処理を追加しました。禁止設定されている場合に「削除可」を含む名前が指定された場合、下記のエラーメッセージを表示します。

![プレイルーム名に「削除可」が含まれる場合、エラーメッセージが表示される](https://cloud.githubusercontent.com/assets/2551173/16808330/0ca32034-4957-11e6-8ea8-27843466051e.png)

## 翻訳メッセージ
翻訳メッセージ disallowRenamingPlayRoomAsDeletable を追加しました。日本語と英語は用意できましたが、中国語と韓国語についてはできませんでした。一時的に英語のものを入れてあります。