### PR TITLE
PlayRoom のコンストラクタ引数を減らす

### DIFF
--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -161,6 +161,10 @@ class DodontoFServer
     return messagePack
   end
 
+  # セーブデータディレクトリの情報
+  # @return [SaveDirInfo]
+  attr_reader :saveDirInfo
+
   def initialize(saveDirInfo, cgiParams)
     @cgiParams = cgiParams
     @saveDirInfo = saveDirInfo
@@ -1221,7 +1225,7 @@ class DodontoFServer
     minRoom = getWebIfRequestInt('minRoom', 0)
     maxRoom = getWebIfRequestInt('maxRoom', ($saveDataMaxCount - 1))
 
-    room = DodontoF::PlayRoom.new(self, @saveDirInfo)
+    room = DodontoF::PlayRoom.new(self)
     playRoomStates = room.getStates(minRoom, maxRoom)
 
     jsonData = {
@@ -1937,18 +1941,18 @@ class DodontoFServer
   end
   
   def removeOldPlayRoom()
-    DodontoF::PlayRoom.new(self, @saveDirInfo).removeOlds
+    DodontoF::PlayRoom.new(self).removeOlds
   end
   
   def getPlayRoomStates()
     params = getParamsFromRequestData()
     @logger.debug(params, "params")
 
-    DodontoF::PlayRoom.new(self, @saveDirInfo).getStatesByParams(params)
+    DodontoF::PlayRoom.new(self).getStatesByParams(params)
   end
   
   def getPlayRoomState(roomNo)
-    DodontoF::PlayRoom.new(self, @saveDirInfo).getState(roomNo)
+    DodontoF::PlayRoom.new(self).getState(roomNo)
   end
   
   def getGameName(gameType)
@@ -2262,17 +2266,17 @@ class DodontoFServer
   
   def createPlayRoom()
     params = getParamsFromRequestData()
-    DodontoF::PlayRoom.new(self, @saveDirInfo).create(params)
+    DodontoF::PlayRoom.new(self).create(params)
   end
   
   def changePlayRoom()
     params = getParamsFromRequestData()
-    DodontoF::PlayRoom.new(self, @saveDirInfo).change(params)
+    DodontoF::PlayRoom.new(self).change(params)
   end
 
   def removePlayRoom()
     params = getParamsFromRequestData()
-    DodontoF::PlayRoom.new(self, @saveDirInfo).remove(params)
+    DodontoF::PlayRoom.new(self).remove(params)
   end
   
   def getTrueSaveFileName(fileName)
@@ -2675,7 +2679,7 @@ class DodontoFServer
     params = getParamsFromRequestData()
     @logger.debug(params, 'params')
 
-    DodontoF::PlayRoom.new(self, @saveDirInfo).check(params)
+    DodontoF::PlayRoom.new(self).check(params)
   end
   
   def loginPassword()

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -158,7 +158,11 @@ class DodontoFServer_MySqlKai
 
     return messagePack
   end
-  
+
+  # セーブデータディレクトリの情報
+  # @return [SaveDirInfo]
+  attr_reader :saveDirInfo
+
   def initialize(saveDirInfo, cgiParams)
     @cgiParams = cgiParams
     @saveDirInfo = saveDirInfo
@@ -1457,7 +1461,7 @@ SQL_TEXT
     minRoom = getWebIfRequestInt('minRoom', 0)
     maxRoom = getWebIfRequestInt('maxRoom', ($saveDataMaxCount - 1))
 
-    room = DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo)
+    room = DodontoF_MySqlKai::PlayRoom.new(self)
     playRoomStates = room.getStates(minRoom, maxRoom)
 
     jsonData = {
@@ -2121,7 +2125,7 @@ SQL_TEXT
   end
 
   def removeOldPlayRoom()
-    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).removeOlds
+    DodontoF_MySqlKai::PlayRoom.new(self).removeOlds
   end
 
   def getPlayRoomStates()
@@ -2130,7 +2134,7 @@ SQL_TEXT
     params = getParamsFromRequestData()
     @logger.debug(params, "params")
 
-    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).getStatesByParams(params)
+    DodontoF_MySqlKai::PlayRoom.new(self).getStatesByParams(params)
   end
 
   def getRoomTimeStamp(where = nil)
@@ -2506,7 +2510,7 @@ SQL_TEXT
   
   def createPlayRoom()
     params = getParamsFromRequestData()
-    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).create(params)
+    DodontoF_MySqlKai::PlayRoom.new(self).create(params)
   end
 
   
@@ -2518,12 +2522,12 @@ SQL_TEXT
 
   def changePlayRoom()
     params = getParamsFromRequestData()
-    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).change(params)
+    DodontoF_MySqlKai::PlayRoom.new(self).change(params)
   end
 
   def removePlayRoom()
     params = getParamsFromRequestData()
-    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).remove(params)
+    DodontoF_MySqlKai::PlayRoom.new(self).remove(params)
   end
 
   def removeSaveDir(roomNo)
@@ -2935,7 +2939,7 @@ SQL_TEXT
 
     params = getParamsFromRequestData()
     @logger.debug(params, 'params')
-    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).check(params)
+    DodontoF_MySqlKai::PlayRoom.new(self).check(params)
   end
 
   def loginPassword()

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -3,10 +3,12 @@
 module DodontoF
   # PlayRoom情報
   class PlayRoom
-    def initialize(server, saveDirInfo)
+    # コンストラクタ
+    # @param [DodontoFServer] server どどんとふサーバー
+    def initialize(server)
       @logger = DodontoF::Logger.instance
       @server = server
-      @saveDirInfo = saveDirInfo
+      @saveDirInfo = server.saveDirInfo
     end
 
     def create(params)

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -3,10 +3,12 @@
 module DodontoF_MySqlKai
   # PlayRoom情報
   class PlayRoom
-    def initialize(server, saveDirInfo)
+    # コンストラクタ
+    # @param [DodontoFServer_MySqlKai] server どどんとふサーバー（MySQL 改）
+    def initialize(server)
       @logger = DodontoF::Logger.instance
       @server = server
-      @saveDirInfo = saveDirInfo
+      @saveDirInfo = server.saveDirInfo
     end
 
     def create(params)


### PR DESCRIPTION
DodontoF::PlayRoomのコンストラクタの引数を減らし、サーバーインスタンスのみを受け取るようにしました。

これまでは `server` と `saveDirInfo` の2つを受け取るようになっていましたが、それらは処理上不可分で、ばらばらに受け取れるほうが整合性の面で不自然です。サーバーが生成時にSaveDirInfoを受け取ってインスタンス変数に格納していることから、サーバーに `saveDirInfo` のgetterを追加し、DodontoF::PlayRoomのコンストラクタはそれを使用するように変更しました。

なお、変更すべき箇所がコミット分のみであることを以下のコマンドで確認しました。

```
$ git grep -n 'PlayRoom\.new'
DodontoFServer.rb:1228:    room = DodontoF::PlayRoom.new(self)
DodontoFServer.rb:1944:    DodontoF::PlayRoom.new(self).removeOlds
DodontoFServer.rb:1951:    DodontoF::PlayRoom.new(self).getStatesByParams(params)
DodontoFServer.rb:1955:    DodontoF::PlayRoom.new(self).getState(roomNo)
DodontoFServer.rb:2269:    DodontoF::PlayRoom.new(self).create(params)
DodontoFServer.rb:2274:    DodontoF::PlayRoom.new(self).change(params)
DodontoFServer.rb:2279:    DodontoF::PlayRoom.new(self).remove(params)
DodontoFServer.rb:2682:    DodontoF::PlayRoom.new(self).check(params)
DodontoFServerMySqlKai.rb:1464:    room = DodontoF_MySqlKai::PlayRoom.new(self)
DodontoFServerMySqlKai.rb:2128:    DodontoF_MySqlKai::PlayRoom.new(self).removeOlds
DodontoFServerMySqlKai.rb:2137:    DodontoF_MySqlKai::PlayRoom.new(self).getStatesByParams(params)
DodontoFServerMySqlKai.rb:2513:    DodontoF_MySqlKai::PlayRoom.new(self).create(params)
DodontoFServerMySqlKai.rb:2525:    DodontoF_MySqlKai::PlayRoom.new(self).change(params)
DodontoFServerMySqlKai.rb:2530:    DodontoF_MySqlKai::PlayRoom.new(self).remove(params)
DodontoFServerMySqlKai.rb:2942:    DodontoF_MySqlKai::PlayRoom.new(self).check(params)
```