### PR TITLE
Image のコンストラクタ引数を減らす

### DIFF
--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2149,7 +2149,7 @@ class DodontoFServer
   
   
   def getLoginWarning
-    image = DodontoF::Image.new(self, @saveDirInfo)
+    image = DodontoF::Image.new(self)
     smallImageDir = image.getSmallImageDir
     unless( isExistDir?(smallImageDir) )
       return {
@@ -3509,7 +3509,7 @@ class DodontoFServer
 
   def uploadImageData()
     params = getParamsFromRequestData()
-    image = DodontoF::Image.new(self, @saveDirInfo)
+    image = DodontoF::Image.new(self)
     image.uploadImageData(params)
   end
   
@@ -3553,7 +3553,7 @@ class DodontoFServer
   
   def deleteImage()
     params = getParamsFromRequestData()
-    image = DodontoF::Image.new(self, @saveDirInfo)
+    image = DodontoF::Image.new(self)
     image.deleteImage(params)
   end
   
@@ -3566,7 +3566,7 @@ class DodontoFServer
   
   def uploadImageUrl()
     imageData = getParamsFromRequestData()
-    image = DodontoF::Image.new(self, @saveDirInfo)
+    image = DodontoF::Image.new(self)
     image.uploadImageUrl(imageData)
   end
   
@@ -4113,7 +4113,7 @@ class DodontoFServer
   
   def changeImageTags()
     effectData = getParamsFromRequestData()
-    image = DodontoF::Image.new(self, @saveDirInfo)
+    image = DodontoF::Image.new(self)
     image.changeImageTags(effectData)
   end
   
@@ -4123,7 +4123,7 @@ class DodontoFServer
   end
   
   def getImageTagsAndImageList
-    image = DodontoF::Image.new(self, @saveDirInfo)
+    image = DodontoF::Image.new(self)
     image.getImageTagsAndImageList()
   end
   

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -161,6 +161,10 @@ class DodontoFServer
     return messagePack
   end
 
+  # セーブデータディレクトリの情報
+  # @return [SaveDirInfo]
+  attr_reader :saveDirInfo
+
   def initialize(saveDirInfo, cgiParams)
     @cgiParams = cgiParams
     @saveDirInfo = saveDirInfo
@@ -1221,7 +1225,7 @@ class DodontoFServer
     minRoom = getWebIfRequestInt('minRoom', 0)
     maxRoom = getWebIfRequestInt('maxRoom', ($saveDataMaxCount - 1))
 
-    room = DodontoF::PlayRoom.new(self, @saveDirInfo)
+    room = DodontoF::PlayRoom.new(self)
     playRoomStates = room.getStates(minRoom, maxRoom)
 
     jsonData = {
@@ -1937,18 +1941,18 @@ class DodontoFServer
   end
   
   def removeOldPlayRoom()
-    DodontoF::PlayRoom.new(self, @saveDirInfo).removeOlds
+    DodontoF::PlayRoom.new(self).removeOlds
   end
   
   def getPlayRoomStates()
     params = getParamsFromRequestData()
     @logger.debug(params, "params")
 
-    DodontoF::PlayRoom.new(self, @saveDirInfo).getStatesByParams(params)
+    DodontoF::PlayRoom.new(self).getStatesByParams(params)
   end
   
   def getPlayRoomState(roomNo)
-    DodontoF::PlayRoom.new(self, @saveDirInfo).getState(roomNo)
+    DodontoF::PlayRoom.new(self).getState(roomNo)
   end
   
   def getGameName(gameType)
@@ -2262,17 +2266,17 @@ class DodontoFServer
   
   def createPlayRoom()
     params = getParamsFromRequestData()
-    DodontoF::PlayRoom.new(self, @saveDirInfo).create(params)
+    DodontoF::PlayRoom.new(self).create(params)
   end
   
   def changePlayRoom()
     params = getParamsFromRequestData()
-    DodontoF::PlayRoom.new(self, @saveDirInfo).change(params)
+    DodontoF::PlayRoom.new(self).change(params)
   end
 
   def removePlayRoom()
     params = getParamsFromRequestData()
-    DodontoF::PlayRoom.new(self, @saveDirInfo).remove(params)
+    DodontoF::PlayRoom.new(self).remove(params)
   end
   
   def getTrueSaveFileName(fileName)
@@ -2675,7 +2679,7 @@ class DodontoFServer
     params = getParamsFromRequestData()
     @logger.debug(params, 'params')
 
-    DodontoF::PlayRoom.new(self, @saveDirInfo).check(params)
+    DodontoF::PlayRoom.new(self).check(params)
   end
   
   def loginPassword()

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2368,7 +2368,7 @@ SQL_TEXT
   
   
   def getLoginWarning
-    image = DodontoF_MySqlKai::Image.new(self, @saveDirInfo)
+    image = DodontoF_MySqlKai::Image.new(self)
     smallImageDir = image.getSmallImageDir()
     unless( isExistDir?(smallImageDir) )
       return {
@@ -3759,7 +3759,7 @@ SQL_TEXT
 
   def uploadImageData()
     params = getParamsFromRequestData()
-    image = DodontoF_MySqlKai::Image.new(self, @saveDirInfo)
+    image = DodontoF_MySqlKai::Image.new(self)
     image.uploadImageData(params)
   end
   
@@ -3793,7 +3793,7 @@ SQL_TEXT
   
   def deleteImage()
     params = getParamsFromRequestData()
-    image = DodontoF_MySqlKai::Image.new(self, @saveDirInfo)
+    image = DodontoF_MySqlKai::Image.new(self)
     image.deleteImage(params)
   end
   
@@ -3806,7 +3806,7 @@ SQL_TEXT
   
   def uploadImageUrl()
     imageData = getParamsFromRequestData()
-    image = DodontoF_MySqlKai::Image.new(self, @saveDirInfo)
+    image = DodontoF_MySqlKai::Image.new(self)
     image.uploadImageUrl(imageData)
   end
   
@@ -4405,7 +4405,7 @@ SQL_TEXT
   
   def changeImageTags()
     effectData = getParamsFromRequestData()
-    image = DodontoF_MySqlKai::Image.new(self, @saveDirInfo)
+    image = DodontoF_MySqlKai::Image.new(self)
     image.changeImageTags(effectData)
   end
   
@@ -4415,7 +4415,7 @@ SQL_TEXT
   end
   
   def getImageTagsAndImageList
-    image = DodontoF_MySqlKai::Image.new(self, @saveDirInfo)
+    image = DodontoF_MySqlKai::Image.new(self)
     image.getImageTagsAndImageList()
   end
   

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -158,7 +158,11 @@ class DodontoFServer_MySqlKai
 
     return messagePack
   end
-  
+
+  # セーブデータディレクトリの情報
+  # @return [SaveDirInfo]
+  attr_reader :saveDirInfo
+
   def initialize(saveDirInfo, cgiParams)
     @cgiParams = cgiParams
     @saveDirInfo = saveDirInfo
@@ -1457,7 +1461,7 @@ SQL_TEXT
     minRoom = getWebIfRequestInt('minRoom', 0)
     maxRoom = getWebIfRequestInt('maxRoom', ($saveDataMaxCount - 1))
 
-    room = DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo)
+    room = DodontoF_MySqlKai::PlayRoom.new(self)
     playRoomStates = room.getStates(minRoom, maxRoom)
 
     jsonData = {
@@ -2121,7 +2125,7 @@ SQL_TEXT
   end
 
   def removeOldPlayRoom()
-    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).removeOlds
+    DodontoF_MySqlKai::PlayRoom.new(self).removeOlds
   end
 
   def getPlayRoomStates()
@@ -2130,7 +2134,7 @@ SQL_TEXT
     params = getParamsFromRequestData()
     @logger.debug(params, "params")
 
-    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).getStatesByParams(params)
+    DodontoF_MySqlKai::PlayRoom.new(self).getStatesByParams(params)
   end
 
   def getRoomTimeStamp(where = nil)
@@ -2506,7 +2510,7 @@ SQL_TEXT
   
   def createPlayRoom()
     params = getParamsFromRequestData()
-    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).create(params)
+    DodontoF_MySqlKai::PlayRoom.new(self).create(params)
   end
 
   
@@ -2518,12 +2522,12 @@ SQL_TEXT
 
   def changePlayRoom()
     params = getParamsFromRequestData()
-    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).change(params)
+    DodontoF_MySqlKai::PlayRoom.new(self).change(params)
   end
 
   def removePlayRoom()
     params = getParamsFromRequestData()
-    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).remove(params)
+    DodontoF_MySqlKai::PlayRoom.new(self).remove(params)
   end
 
   def removeSaveDir(roomNo)
@@ -2935,7 +2939,7 @@ SQL_TEXT
 
     params = getParamsFromRequestData()
     @logger.debug(params, 'params')
-    DodontoF_MySqlKai::PlayRoom.new(self, @saveDirInfo).check(params)
+    DodontoF_MySqlKai::PlayRoom.new(self).check(params)
   end
 
   def loginPassword()

--- a/src_ruby/dodontof/image.rb
+++ b/src_ruby/dodontof/image.rb
@@ -3,10 +3,13 @@
 module DodontoF
   # Image情報
   class Image
-    def initialize(server, saveDirInfo)
+    # コンストラクタ
+    # @param [DodontoFServer, DodontoFServer_MySqlKai]
+    #   server どどんとふサーバー
+    def initialize(server)
       @logger = DodontoF::Logger.instance
       @server = server
-      @saveDirInfo = saveDirInfo
+      @saveDirInfo = server.saveDirInfo
     end
 
     def deleteImage(params)

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -441,7 +441,7 @@ module DodontoF
     end
 
     def removePlayRoomData(roomNumber)
-      image = DodontoF::Image.new(@server, @saveDirInfo)
+      image = DodontoF::Image.new(@server)
       image.removeRoomImageTags(roomNumber)
       @saveDirInfo.removeSaveDir(roomNumber)
       removeLocalSpaceDir(roomNumber)

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -3,10 +3,12 @@
 module DodontoF
   # PlayRoom情報
   class PlayRoom
-    def initialize(server, saveDirInfo)
+    # コンストラクタ
+    # @param [DodontoFServer] server どどんとふサーバー
+    def initialize(server)
       @logger = DodontoF::Logger.instance
       @server = server
-      @saveDirInfo = saveDirInfo
+      @saveDirInfo = server.saveDirInfo
     end
 
     def create(params)

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -3,10 +3,12 @@
 module DodontoF_MySqlKai
   # PlayRoom情報
   class PlayRoom
-    def initialize(server, saveDirInfo)
+    # コンストラクタ
+    # @param [DodontoFServer_MySqlKai] server どどんとふサーバー（MySQL 改）
+    def initialize(server)
       @logger = DodontoF::Logger.instance
       @server = server
-      @saveDirInfo = saveDirInfo
+      @saveDirInfo = server.saveDirInfo
     end
 
     def create(params)

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -414,7 +414,7 @@ COMMAND_END
     end
 
     def removePlayRoomData(roomNumber)
-      image = DodontoF_MySqlKai::Image.new(@server, @saveDirInfo)
+      image = DodontoF_MySqlKai::Image.new(@server)
       image.removeRoomImageTags(roomNumber)
       @saveDirInfo.removeSaveDir(roomNumber)
       removeLocalSpaceDir(roomNumber)

--- a/test_ruby/test_DodontoFServer.rb
+++ b/test_ruby/test_DodontoFServer.rb
@@ -603,9 +603,8 @@ class DodontoFServerTest < Test::Unit::TestCase
       'params' => { }
     }
 
-    info = SaveDirInfo.new
-    server = getDodontoFServerForTest.new(info, params)
-    image = DodontoF::Image.new(server, info)
+    server = getDodontoFServerForTest.new(SaveDirInfo.new, params)
+    image = DodontoF::Image.new(server)
     target = image.getSmallImageDir
     FileUtils.rm_r(target)
 


### PR DESCRIPTION
#43 の続きです。DodontoF::Imageにも同様の変更ができました。

変更すべき箇所は以下のように確認しました。

```
$ git grep -n 'Image\.new'
DodontoFServer.rb:2167:    image = DodontoF::Image.new(self, @saveDirInfo)
DodontoFServer.rb:3527:    image = DodontoF::Image.new(self, @saveDirInfo)
DodontoFServer.rb:3571:    image = DodontoF::Image.new(self, @saveDirInfo)
DodontoFServer.rb:3584:    image = DodontoF::Image.new(self, @saveDirInfo)
DodontoFServer.rb:4131:    image = DodontoF::Image.new(self, @saveDirInfo)
DodontoFServer.rb:4141:    image = DodontoF::Image.new(self, @saveDirInfo)
DodontoFServerMySqlKai.rb:2367:    image = DodontoF_MySqlKai::Image.new(self, @saveDirInfo)
DodontoFServerMySqlKai.rb:3758:    image = DodontoF_MySqlKai::Image.new(self, @saveDirInfo)
DodontoFServerMySqlKai.rb:3792:    image = DodontoF_MySqlKai::Image.new(self, @saveDirInfo)
DodontoFServerMySqlKai.rb:3805:    image = DodontoF_MySqlKai::Image.new(self, @saveDirInfo)
DodontoFServerMySqlKai.rb:4404:    image = DodontoF_MySqlKai::Image.new(self, @saveDirInfo)
DodontoFServerMySqlKai.rb:4414:    image = DodontoF_MySqlKai::Image.new(self, @saveDirInfo)
src_ruby/dodontof/play_room.rb:442:      image = DodontoF::Image.new(@server, @saveDirInfo)
src_ruby/dodontof_mysqlkai/play_room.rb:415:      image = DodontoF_MySqlKai::Image.new(@server, @saveDirInfo)
test_ruby/test_DodontoFServer_client_login_commands.rb:92:    image = DodontoF::Image.new(server, saveDirInfo)
```