### PR TITLE
.gitignore に SWF と config_local を追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+DodontoF.swf
+/src_ruby/config_local.rb
 /.temp
 /test_log.txt


### PR DESCRIPTION
コミット時に DodontoF.swf と config_local.rb が混入されないよう、.gitignore に追加しました。