### PR TITLE
Travis CI の Ruby バージョン指定を更新する

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.3.1
   - 2.2
   - 2.0
   - 1.9


### PR DESCRIPTION
[Travis CI](https://travis-ci.org/) での自動テストの対象 Ruby バージョンに、公式鯖や TRPG.NET で使われている 2.3.1 を追加しました。

先日起こった「Ruby 1.8.7 の場合のみ動作しない」といった問題を早く検知できるので、どどんとふでも Travis CI での複数の Ruby バージョンを対象にした自動テストを有効にすることをお勧めいたします。
[BCDice では有効になっています](https://travis-ci.org/torgtaitai/BCDice)ので、Travis CI の竹流さんのプロフィールページから簡単に有効化できるはずです。