### PR TITLE
未使用の isJsonResult を除く・応答の Content-Type を application/json に変更する

### DIFF
--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -170,7 +170,6 @@ class DodontoFServer
     roomIndexKey = "room"
     initSaveFiles( getRequestData(roomIndexKey) )
 
-    @isAddMarker = false
     @jsonpCallBack = nil
     @isWebIf = false
     @isJsonResult = true
@@ -243,7 +242,6 @@ class DodontoFServer
     return valueWebIf
   end
 
-  attr :isAddMarker
   attr :jsonpCallBack
   attr :isJsonResult
   
@@ -874,11 +872,6 @@ class DodontoFServer
     
     if( isInvalidRequestParam(commandName) )
       return nil
-    end
-    
-    marker = getRequestData('marker')
-    if( isInvalidRequestParam(marker) )
-      @isAddMarker = false
     end
     
     @logger.debug(commandName, "commandName")
@@ -5751,10 +5744,6 @@ def printResult(server)
 
   begin
     result = server.getResponse
-
-    if( server.isAddMarker )
-      result = "#D@EM>#" + result + "#<D@EM#";
-    end
 
     if( server.jsonpCallBack )
       result = "#{server.jsonpCallBack}(" + result + ");";

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -172,7 +172,6 @@ class DodontoFServer
 
     @jsonpCallBack = nil
     @isWebIf = false
-    @isJsonResult = true
     @isRecordEmpty = false
 
     @diceBotTablePrefix = 'diceBotTable_'
@@ -243,7 +242,6 @@ class DodontoFServer
   end
 
   attr :jsonpCallBack
-  attr :isJsonResult
   
   def getCardsInfo
     require "card"
@@ -865,7 +863,6 @@ class DodontoFServer
     @logger.debug("analyzeWebInterfaceCatched begin")
     
     @isWebIf = true
-    @isJsonResult = true
     
     commandName = getRequestData('webif')
     @logger.debug(commandName, 'commandName')
@@ -5658,13 +5655,8 @@ class DodontoFServer
         analyzeCommand
       end
 
-    if isJsonResult
-      return getJsonString(response)
-    else
-      return MessagePack.pack(response)
-    end
+    return getJsonString(response)
   end
-  
 end
 
 
@@ -5716,23 +5708,6 @@ def main(cgiParams)
   logger.debug("printResult called")
 end
 
-def getInitializedHeaderText(server)
-  header = ""
-  
-  if( $isModRuby )
-    #Apache::request.content_type = "text/plain; charset=utf-8"
-    #Apache::request.send_header
-  else
-    if( server.isJsonResult )
-      header = "Content-Type: text/plain; charset=utf-8\n"
-    else
-      header = "Content-Type: application/x-msgpack; charset=x-user-defined\n"
-    end
-  end
-  
-  return header
-end
-
 def printResult(server)
   logger = DodontoF::Logger.instance
 
@@ -5740,7 +5715,7 @@ def printResult(server)
 
   text = "empty"
 
-  header = getInitializedHeaderText(server)
+  header = $isModRuby ? '' : "Content-Type: application/json\n"
 
   begin
     result = server.getResponse

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -170,7 +170,6 @@ class DodontoFServer_MySqlKai
 
     @jsonpCallBack = nil
     @isWebIf = false
-    @isJsonResult = true
 
     @diceBotTablePrefix = 'diceBotTable_'
     @dice_adapter = DodontoF::DiceAdapter.new(getDiceBotExtraTableDirName, @diceBotTablePrefix)
@@ -232,7 +231,6 @@ class DodontoFServer_MySqlKai
   end
 
   attr :jsonpCallBack
-  attr :isJsonResult
   
   def getCardsInfo
     require "card.rb"
@@ -541,7 +539,6 @@ class DodontoFServer_MySqlKai
     @logger.debug("analyzeWebInterfaceCatched begin")
     
     @isWebIf = true
-    @isJsonResult = true
     
     commandName = getRequestData('webif')
     @logger.debug(commandName, 'commandName')
@@ -5814,13 +5811,8 @@ SQL_TEXT
         analyzeCommand
       end
 
-    if isJsonResult
-      return getJsonString(response)
-    else
-      return MessagePack.pack(response)
-    end
+    return getJsonString(response)
   end
-  
 end
 
 
@@ -5872,23 +5864,6 @@ def main(cgiParams)
   logger.debug("printResult called")
 end
 
-def getInitializedHeaderText(server)
-  header = ""
-  
-  if( $isModRuby )
-    #Apache::request.content_type = "text/plain; charset=utf-8"
-    #Apache::request.send_header
-  else
-    if( server.isJsonResult )
-      header = "Content-Type: text/plain; charset=utf-8\n"
-    else
-      header = "Content-Type: application/x-msgpack; charset=x-user-defined\n"
-    end
-  end
-  
-  return header
-end
-
 def printResult(server)
   logger = DodontoF::Logger.instance
 
@@ -5896,7 +5871,7 @@ def printResult(server)
 
   text = "empty"
 
-  header = getInitializedHeaderText(server)
+  header = $isModRuby ? '' : "Content-Type: application/json\n"
 
   begin
     result = server.getResponse

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -168,7 +168,6 @@ class DodontoFServer_MySqlKai
     roomIndexKey = "room"
     initSaveFiles( getRequestData(roomIndexKey) )
 
-    @isAddMarker = false
     @jsonpCallBack = nil
     @isWebIf = false
     @isJsonResult = true
@@ -232,7 +231,6 @@ class DodontoFServer_MySqlKai
     return valueWebIf
   end
 
-  attr :isAddMarker
   attr :jsonpCallBack
   attr :isJsonResult
   
@@ -550,11 +548,6 @@ class DodontoFServer_MySqlKai
     
     if( isInvalidRequestParam(commandName) )
       return nil
-    end
-    
-    marker = getRequestData('marker')
-    if( isInvalidRequestParam(marker) )
-      @isAddMarker = false
     end
     
     @logger.debug(commandName, "commandName")
@@ -5907,10 +5900,6 @@ def printResult(server)
 
   begin
     result = server.getResponse
-
-    if( server.isAddMarker )
-      result = "#D@EM>#" + result + "#<D@EM#";
-    end
 
     if( server.jsonpCallBack )
       result = "#{server.jsonpCallBack}(" + result + ");";

--- a/README.html
+++ b/README.html
@@ -665,8 +665,6 @@ playRoomStates：各部屋の情報の配列。以下、その内容<br>
 　　　（Flashからの定期取得処理と同一の動作）<br>
 　sec：何秒前までのチャットを取得するかの指定。allなら全取得、省略なら過去180秒（$oldMessageTimeoutで指定）<br>
 <br>
-　marker：基本不要。trueを設定することで、JSONの前後に #D@EM&lt;#(JSON)#&gt;D@EM# とマーカーを付与（CGI広告埋め込み対策）<br>
-<br>
 コマンド例）<br>
 　DodontoFServer.rb?webif=chat&room=0&password=himitsu&time=1339209851.85239&callback=responseFunction<br>
 <br>

--- a/README.md
+++ b/README.md
@@ -658,8 +658,6 @@ playRoomStates：各部屋の情報の配列。以下、その内容<br>
 　　　（Flashからの定期取得処理と同一の動作）<br>
 　sec：何秒前までのチャットを取得するかの指定。allなら全取得、省略なら過去180秒（$oldMessageTimeoutで指定）<br>
 <br>
-　marker：基本不要。trueを設定することで、JSONの前後に #D@EM&lt;#(JSON)#&gt;D@EM# とマーカーを付与（CGI広告埋め込み対策）<br>
-<br>
 コマンド例）<br>
 　DodontoFServer.rb?webif=chat&room=0&password=himitsu&time=1339209851.85239&callback=responseFunction<br>
 <br>


### PR DESCRIPTION
#47 の続きです。`isAddMarker` と同様に、`isJsonResult` も `@isJsonRsult` に `true` しか代入されないため、分岐の片方がデッドコードとなっています。
そこで、`isJsonResult` も除くことで、コードを単純にすることができます。

また、応答の形式が JSON にしかならないため、応答の Content-Type を [RFC 7159 で定められている](https://tools.ietf.org/html/rfc7159#section-11) application/json に変更しました。

さらに、同じく [RFC 7159 に従って](https://tools.ietf.org/html/rfc7159#appendix-A)（<q>clarifying the absence
      of a "charset" parameter</q> とあります）Content-Type の charset を除きました。
JSON の文字コードは Unicode と規定されている上、パーサーによって自動的に UTF-8 に判別されるため、含める必要がありません。