### PR TITLE
Ruby 2.2でもCIでテストできるように

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ rvm:
   - 2.0
   - 1.9
   - 1.8
+
+install: gem install test-unit --no-ri --no-rdoc


### PR DESCRIPTION
Ruby 2.2系にはtest-unitが同梱されていないため、CIが走るたびに落ちてしまっている。
そこでCI起動時ににtest-unit gemをインストールするように設定する。