### PR TITLE
mysqlデフォルトの場合にDodontoFServer.rbを呼ぶとエラーになる問題の修正

### DIFF
--- a/DodontoFServerMySql.rb
+++ b/DodontoFServerMySql.rb
@@ -3,7 +3,9 @@
 
 $LOAD_PATH << File.dirname(__FILE__) # require_relative対策
 
-require 'DodontoFServer.rb'
+if( $0 === __FILE__ )
+  require 'DodontoFServer.rb'
+end
 #require 'rubygems'
 require 'mysql'
 


### PR DESCRIPTION
config.rbにてmysqlを有効化した環境においてmainMySqlが見つからないエラーを発生する問題の修正PRになります。

# エラーの発生プロセス
1. swfからDodontoFServer.rbを呼びだされる
2. 下記の行からDodontoFServerMySql.rbがrequireされるhttps://github.com/torgtaitai/DodontoF/blob/master/DodontoFServer.rb#L5801
3. DodontoFServerMySql.rbの下記の行にてDodontoFServer.rbがrequireされる
https://github.com/torgtaitai/DodontoF/blob/master/DodontoFServerMySql.rb#L6
4. 2.と同じ行まで読み込まれたときにrubyが循環していることを検知する
5. まだmainMySqlが読み込まれていないのでエラーを返す

# 対策
DodontoFServer.rb側からrequireされた(DodontFSererMySql.rbが直接呼びされていない)場合 、DodontoFServerMySql.rbはDodontoFServer.rbをrequireしない

- DodontoFServer.rbからrequireされる場合はすでにRubyはDodontoFServer.rb側のメソッドは読み込んでいるので不要のはず