### PR TITLE
Gemfileを復活させる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,13 @@
+source 'https://rubygems.org'
+
+gem 'msgpack'
+
+group :development, :test do
+  if RUBY_VERSION < '1.9'
+    gem 'rake', '~> 10.5'
+    gem 'test-unit', '1.2.3'
+  else
+    gem 'rake'
+    gem 'test-unit'
+  end
+end


### PR DESCRIPTION
#54 「Gemfileを追加する」で入れたGemfileがv1.48.19でなぜか消されてしまった結果、再びRuby 2.2.5でのテストで失敗するようになってしまったので、もう一度追加するものです。
