### PR TITLE
getDiceBotInfosの修正

### DIFF
--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2233,7 +2233,8 @@ class DodontoFServer
     @logger.debug("getDiceBotInfos() Begin")
     
     require 'diceBotInfos'
-    diceBotInfos = DiceBotInfos.new.getInfos
+    diceBotInfos = DiceBotInfos.get($diceBotOrder.split("\n"),
+                                    $isDisplayAllDice)
     
     commandInfos = getGameCommandInfos
     

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -2229,62 +2229,24 @@ class DodontoFServer
     return loginMessage
   end
   
-  def getDiceBotInfos()
+  # ダイスボットの情報を返す
+  # @return [Array<Hash>]
+  #
+  # 部屋番号が指定されていた場合、テーブルのコマンドも含める。
+  def getDiceBotInfos
     @logger.debug("getDiceBotInfos() Begin")
     
     require 'diceBotInfos'
-    diceBotInfos = DiceBotInfos.get($diceBotOrder.split("\n"),
-                                    $isDisplayAllDice)
-    
-    commandInfos = getGameCommandInfos
-    
-    commandInfos.each do |commandInfo|
-      @logger.debug(commandInfo, "commandInfos.each commandInfos")
-      setDiceBotPrefix(diceBotInfos, commandInfo)
-    end
-    
-    # @logger.debug(diceBotInfos, "getDiceBotInfos diceBotInfos")
-    
-    return diceBotInfos
-  end
-  
-  def setDiceBotPrefix(diceBotInfos, commandInfo)
-    gameType = commandInfo["gameType"]
-    
-    if( gameType.empty? )
-      setDiceBotPrefixToAll(diceBotInfos, commandInfo)
-      return
-    end
-    
-    botInfo = diceBotInfos.find{|i| i["gameType"] == gameType}
-    setDiceBotPrefixToOne(botInfo, commandInfo)
-  end
-  
-  def setDiceBotPrefixToAll(diceBotInfos, commandInfo)
-    diceBotInfos.each do |botInfo|
-      setDiceBotPrefixToOne(botInfo, commandInfo)
-    end
-  end
-  
-  def setDiceBotPrefixToOne(botInfo, commandInfo)
-    @logger.debug(botInfo, "botInfo")
-    return if(botInfo.nil?)
-    
-    prefixs = botInfo["prefixs"]
-    return if( prefixs.nil? )
-    
-    prefixs << commandInfo["command"]
-  end
-  
-  def getGameCommandInfos
-    @logger.debug('getGameCommandInfos Begin')
 
-    if( @saveDirInfo.getSaveDataDirIndex == -1 )
-      @logger.debug('getGameCommandInfos room is -1, so END')
-      return []
-    end
+    orderedGameNames = $diceBotOrder.split("\n")
 
-    @dice_adapter.getGameCommandInfos
+    if @saveDirInfo.getSaveDataDirIndex != -1
+      DiceBotInfos.withTableCommands(orderedGameNames,
+                                     $isDisplayAllDice,
+                                     @dice_adapter.getGameCommandInfos)
+    else
+      DiceBotInfos.get(orderedGameNames, $isDisplayAllDice)
+    end
   end
 
   def createDir(playRoomIndex)

--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -1980,18 +1980,6 @@ class DodontoFServer
     DodontoF::PlayRoom.new(self).getState(roomNo)
   end
   
-  def getGameName(gameType)
-    require 'diceBotInfos'
-    diceBotInfos = DiceBotInfos.new.getInfos
-    gameInfo = diceBotInfos.find{|i| i["gameType"] == gameType}
-    
-    return '--' if( gameInfo.nil? )
-    
-    return gameInfo["name"]
-  end
-  
-  
-  
   def getAllLoginCount()
     roomNumberRange = (0 .. $saveDataMaxCount)
     loginUserCountList = getLoginUserCountList( roomNumberRange )

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2171,18 +2171,6 @@ SQL_TEXT
     return result
   end
   
-  
-  def getGameName(gameType)
-    require 'diceBotInfos'
-    diceBotInfos = DiceBotInfos.new.getInfos
-    gameInfo = diceBotInfos.find{|i| i["gameType"] == gameType}
-    
-    return '--' if( gameInfo.nil? )
-    
-    return gameInfo["name"]
-  end
-  
-  
   def getAllLoginCount()
     total = 0
     userList = []

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2407,65 +2407,25 @@ SQL_TEXT
     return loginMessage
   end
   
-  def getDiceBotInfos()
+  # ダイスボットの情報を返す
+  # @return [Array<Hash>]
+  #
+  # 部屋番号が指定されていた場合、テーブルのコマンドも含める。
+  def getDiceBotInfos
     @logger.debug("getDiceBotInfos() Begin")
     
     require 'diceBotInfos'
-    diceBotInfos = DiceBotInfos.get($diceBotOrder.split("\n"),
-                                    $isDisplayAllDice)
-    
-    commandInfos = getGameCommandInfos
-    
-    commandInfos.each do |commandInfo|
-      @logger.debug(commandInfo, "commandInfos.each commandInfos")
-      setDiceBotPrefix(diceBotInfos, commandInfo)
-    end
-    
-    # @logger.debug(diceBotInfos, "getDiceBotInfos diceBotInfos")
-    
-    return diceBotInfos
-  end
-  
-  def setDiceBotPrefix(diceBotInfos, commandInfo)
-    gameType = commandInfo["gameType"]
-    
-    if( gameType.empty? )
-      setDiceBotPrefixToAll(diceBotInfos, commandInfo)
-      return
-    end
-    
-    botInfo = diceBotInfos.find{|i| i["gameType"] == gameType}
-    setDiceBotPrefixToOne(botInfo, commandInfo)
-  end
-  
-  def setDiceBotPrefixToAll(diceBotInfos, commandInfo)
-    diceBotInfos.each do |botInfo|
-      setDiceBotPrefixToOne(botInfo, commandInfo)
-    end
-  end
-  
-  def setDiceBotPrefixToOne(botInfo, commandInfo)
-    @logger.debug(botInfo, "botInfo")
-    return if(botInfo.nil?)
-    
-    prefixs = botInfo["prefixs"]
-    return if( prefixs.nil? )
-    
-    prefixs << commandInfo["command"]
-  end
-  
-  def getGameCommandInfos
-    @logger.debug('getGameCommandInfos Begin')
 
-    if( @saveDirInfo.getSaveDataDirIndex == -1 )
-      @logger.debug('getGameCommandInfos room is -1, so END')
+    orderedGameNames = $diceBotOrder.split("\n")
 
-      return []
+    if @saveDirInfo.getSaveDataDirIndex != -1
+      DiceBotInfos.withTableCommands(orderedGameNames,
+                                     $isDisplayAllDice,
+                                     @dice_adapter.getGameCommandInfos)
+    else
+      DiceBotInfos.get(orderedGameNames, $isDisplayAllDice)
     end
-
-    return @dice_adapter.getGameCommandInfos
   end
-  
   
   def createDir(playRoomIndex)
     @logger.debug("createDir BEGIN")

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -2411,7 +2411,8 @@ SQL_TEXT
     @logger.debug("getDiceBotInfos() Begin")
     
     require 'diceBotInfos'
-    diceBotInfos = DiceBotInfos.new.getInfos
+    diceBotInfos = DiceBotInfos.get($diceBotOrder.split("\n"),
+                                    $isDisplayAllDice)
     
     commandInfos = getGameCommandInfos
     

--- a/src_ruby/diceBotInfos.rb
+++ b/src_ruby/diceBotInfos.rb
@@ -2,10 +2,18 @@
 
 require 'dodontof/logger'
 
+# ダイスボットの情報の一覧の取得処理
 class DiceBotInfos
-  
-  def initialize
-    @baseDiceBot = {
+  # ダイスボット指定なしの場合の情報
+  NONE_DICE_BOT_INFO = {
+    'name' => 'ダイスボット(指定無し)',
+    'gameType' => 'DiceBot',
+    'prefixs' => [],
+    'info' => "ゲーム固有の判定がある場合はこの場所に記載されます。\n"
+  }
+
+  # 基本的なダイスボットの情報
+  BASE_DICE_BOT_INFO = {
     'name' => 'BaseDiceBot',
     'gameType' => 'BaseDiceBot',
     'prefixs' => [
@@ -20,7 +28,7 @@ class DiceBotInfos
       '\d+[\+\-\*\/]', #a+xDn のような加減算用
       'D66', #D66ダイス
       'make', #ランダムジェネレータ用
-      'choice\[', #ランダム選択　(choice[A, B, C])
+      'choice\[' #ランダム選択　(choice[A, B, C])
     ],
     'info' => <<INFO_MESSAGE_TEXT
 【ダイスボット】チャットにダイス用の文字を入力するとダイスロールが可能
@@ -41,77 +49,76 @@ class DiceBotInfos
 　3d6/2 ： ダイス出目を割り算（切り捨て）。切り上げは /2U、四捨五入は /2R。
 　D66 ： D66ダイス。順序はゲームに依存。D66N：そのまま、D66S：昇順。
 INFO_MESSAGE_TEXT
-    }
-    
-    noneDiceBot = {
-    'name' => 'ダイスボット(指定無し)',
-    'gameType' => 'DiceBot',
-    'prefixs' => [
-    ],
-    'info' => <<INFO_MESSAGE_TEXT
-ゲーム固有の判定がある場合はこの場所に記載されます。
-INFO_MESSAGE_TEXT
-    }
-    
-    @infos = [noneDiceBot,
-             ]
+  }
 
-    @logger = DodontoF::Logger.instance
+  # 収集時に無視するボット名
+  BOT_NAMES_TO_IGNORE = [
+    'DiceBot',
+    'DiceBotLoader',
+    'DiceBotLoaderList',
+    'baseBot',
+    '_Template',
+    'test'
+  ]
+
+  # ダイスボットディレクトリに含まれるダイスボットを収集する
+  # @return [Array<DiceBot>]
+  # @see https://github.com/torgtaitai/BCDice/commit/11ee56c8dfdb00ac232c8b5cbf87a963d37df974
+  # @todo BCDiceをコミット11ee56c以降に更新すると、BCDice側のDiceBotLoader.collectDiceBotsで行える
+  #
+  # BCDiceからのバックポート。
+  def self.collectDiceBots
+    diceBotDir = File.expand_path('../src_bcdice/diceBot', File.dirname(__FILE__))
+
+    require("#{diceBotDir}/DiceBot")
+
+    botFiles = Dir.glob("#{diceBotDir}/*.rb")
+    botNames =
+      botFiles.map { |botFile| File.basename(botFile, '.rb').untaint }
+    validBotNames =
+      # 特別な名前のものを除外する
+      (botNames - BOT_NAMES_TO_IGNORE).
+      # 正しいクラス名になるものだけ選ぶ
+      select { |botName| /\A[A-Z]/ === botName }
+
+    validBotNames.map { |botName|
+      require("#{diceBotDir}/#{botName}")
+      Object.const_get(botName).new
+    }
   end
-  
-  
-  def getInfos
-    
-    @orders = getDiceBotOrder
-    
-    addAnotherDiceBotToInfos()
-    sortInfos()
-    deleteInfos() unless( $isDisplayAllDice )
-    
-    @infos << @baseDiceBot
-    
-    return @infos
+
+  # ダイスボットの情報の一覧を取得する
+  # @param [Array<String>] orderedGameNames 順序付けられたゲーム名の配列
+  # @param [Boolean] showAllDiceBots すべてのダイスボットを表示するか
+  # @return [Array<Hash>]
+  def self.get(orderedGameNames, showAllDiceBots)
+    diceBots = self.collectDiceBots
+
+    # ゲーム名 => ダイスボットの対応を作る
+    diceBotFor = Hash[
+      diceBots.map { |diceBot| [diceBot.gameName, diceBot] }
+    ]
+    toDiceBot = lambda { |gameName| diceBotFor[gameName] }
+
+    orderedEnabledDiceBots = orderedGameNames.
+      map(&toDiceBot).
+      # ゲーム名が誤記されていた場合nilになるので除く
+      compact
+
+    orderedDiceBots =
+      if showAllDiceBots
+        disabledGameNames = diceBotFor.keys - orderedGameNames
+        orderedDisabledDiceBots = disabledGameNames.
+          sort.
+          map(&toDiceBot)
+
+        # 一覧に記載されていたゲーム→記載されていなかったゲームの順
+        orderedEnabledDiceBots + orderedDisabledDiceBots
+      else
+        orderedEnabledDiceBots
+      end
+
+    # 指定なし→各ゲーム→基本の順で返す
+    [NONE_DICE_BOT_INFO] + orderedDiceBots.map(&:info) + [BASE_DICE_BOT_INFO]
   end
-  
-  def deleteInfos
-    @logger.debug(@orders, '@orders')
-    
-    @infos.delete_if do |info|
-      not @orders.include?(info['name'])
-    end
-  end
-  
-  def sortInfos
-    @infos = @infos.sort_by do |info|
-      index = @orders.index(info['name'])
-      index ||= 999
-      index.to_i
-    end
-  end
-  
-  def getDiceBotOrder
-    orders = $diceBotOrder.split("\n")
-    return orders
-  end
-  
-  
-  def addAnotherDiceBotToInfos
-    ignoreBotNames = ['DiceBot', 'DiceBotLoader', 'baseBot', '_Template', 'test']
-    
-    require 'diceBot/DiceBot'
-    
-    botFiles = Dir.glob("src_bcdice/diceBot/*.rb")
-    
-    botNames = botFiles.collect{|i| File.basename(i, ".rb").untaint}
-    botNames.delete_if{|i| ignoreBotNames.include?(i) }
-    botNames.delete_if{|i| /^_/ === i }
-    
-    botNames.each do |botName|
-      @logger.debug(botName, 'load unknown dice bot botName')
-      require "diceBot/#{botName}"
-      diceBot = Module.const_get(botName).new
-      @infos << diceBot.info
-    end
-  end
-  
 end


### PR DESCRIPTION
BCDiceの「ダイスコマンドの実行の高速化」(https://github.com/torgtaitai/BCDice/pull/31) を適用すると、どどんとふのサーバー側でgetDiceBotInfosの実行に失敗するため、その部分を修正しました。

エラーの原因は、setDiceBotPrefixToOneにおいて、extratables等のテーブルのコマンドをprefixsで返された接頭辞の配列に破壊的に追加していたことでした。ダイスボット側で接頭辞の配列をfreezeするようにしたため、この追加ができずに例外が発生しました。

このエラーを解消するため、ダイスボットから返された情報を破壊せず加工するように変更しました。また、処理をほぼすべてDiceBotInfosに移動してサーバー本体の分担を減らしました。