### PR TITLE
配布アーカイブを自動で生成するスクリプトの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ DodontoF.swf
 /src_ruby/config_local.rb
 /.temp
 /test_log.txt
+/dist/

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ group :development, :test do
   else
     gem 'rake'
     gem 'test-unit'
+    gem 'rubyzip'
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,56 +1,11 @@
-#--*-coding:utf-8-*--
+# -*- coding: utf-8 -*-
 
-require "rake/testtask"
+require 'rake/clean'
+
+Dir.glob('tasks/*.rake') do |rake_file|
+  load(rake_file)
+end
 
 task :default => :test
 
-Rake::TestTask.new(:test_libs) do |t|
-  t.test_files = ['test_ruby/test*.rb', 'test_ruby/dodontof/**/test*.rb']
-end
-
-Rake::TestTask.new(:test_cgi) do |t|
-  t.test_files = ['test_ruby/cgi/test*.rb']
-end
-
-desc 'すべてのテストを行う'
-task :test do
-  failures = []
-
-  puts('[ライブラリのテスト]')
-  begin
-    Rake::Task['test_libs'].execute
-  rescue
-    failures << 'ライブラリ'
-  end
-
-  puts
-  puts('[CGI のテスト]')
-  begin
-    Rake::Task['test_cgi'].execute
-  rescue
-    failures << 'CGI'
-  end
-
-  unless failures.empty?
-    raise "テスト失敗: #{failures.join(', ')}"
-  end
-end
-
-desc 'SWF ファイルを作成する'
-task :swf do
-  mxmlc = 'mxmlc'
-  options = [
-    '-target-player=10.0.12',
-    '-define=TEST::isTest,false',
-    '-define=COMPILE::isReplayer,false',
-    '-define=COMPILE::isMySql,false',
-    '-include-libraries+=./corelib/bin/corelib.swc',
-    '-o ../DodontoF.swf'
-  ]
-  input = 'DodontoF.mxml'
-  command = ([mxmlc] + options + [input]).join(' ')
-
-  Dir.chdir('src_actionScript') do
-    sh(command)
-  end
-end
+CLOBBER.include('DodontoF.swf')

--- a/tasks/dist.rake
+++ b/tasks/dist.rake
@@ -13,7 +13,7 @@ if RUBY_VERSION >= '1.9.2'
       dodontof_server_rb = "#{dodontof_root}/DodontoFServer.rb"
 
       version = catch(:version_found) do
-        File.open(dodontof_server_rb) do |f|
+        File.open(dodontof_server_rb, 'r:UTF-8') do |f|
           version_pattern = /\A\s*VERSION\s*=\s*(?:'([.\d]+)'|"([.\d]+)")/
           while line = f.gets
             m = line.match(version_pattern)
@@ -32,7 +32,7 @@ if RUBY_VERSION >= '1.9.2'
     # @return [String]
     def current_commit_id(dodontof_root)
       current_commit_id = Dir.chdir(dodontof_root) do
-        `git log -1 --format='%h'`
+        `git log -1 --format=%h`
       end
 
       if !current_commit_id || current_commit_id.empty?
@@ -97,6 +97,7 @@ if RUBY_VERSION >= '1.9.2'
       zip_filename = nil
       loop do
         print('どちらのファイル名で保存しますか? [V/c] > ')
+        $stdout.flush
 
         line = $stdin.gets
         abort unless line
@@ -111,6 +112,7 @@ if RUBY_VERSION >= '1.9.2'
         end
       end
 
+      puts
       rm_rf(zip_filename)
 
       zf_dodontof = ZipFileGenerator.new('DodontoF_WebSet', zip_filename)

--- a/tasks/dist.rake
+++ b/tasks/dist.rake
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+
+if RUBY_VERSION >= '1.9.2'
+  require_relative 'zip_recursive'
+
+  module DodontoFDist
+    module_function
+
+    # DodontoFServer.rbからどどんとふのバージョンを取得する
+    # @param [String] dodontof_root どどんとふのルートディレクトリ
+    # @return [String]
+    def dodontof_version(dodontof_root)
+      dodontof_server_rb = "#{dodontof_root}/DodontoFServer.rb"
+
+      version = catch(:version_found) do
+        File.open(dodontof_server_rb) do |f|
+          version_pattern = /\A\s*VERSION\s*=\s*(?:'([.\d]+)'|"([.\d]+)")/
+          while line = f.gets
+            m = line.match(version_pattern)
+            throw(:version_found, m[1] || m[2]) if m
+          end
+        end
+
+        raise 'DodontoFServer.rbにバージョン情報が含まれていません'
+      end
+
+      version
+    end
+
+    # 現在のコミットIDを取得する
+    # @param [String] dodontof_root どどんとふのルートディレクトリ
+    # @return [String]
+    def current_commit_id(dodontof_root)
+      current_commit_id = Dir.chdir(dodontof_root) do
+        `git log -1 --format='%h'`
+      end
+
+      if !current_commit_id || current_commit_id.empty?
+        raise '現在のコミットIDの取得に失敗しました'
+      end
+
+      current_commit_id.chomp
+    end
+  end
+
+  desc '配布アーカイブを作成する'
+  task :dist do
+    unless File.exist?('DodontoF.swf')
+      Rake::Task['swf'].execute
+    end
+
+    dodontof_root = File.expand_path('..', File.dirname(__FILE__))
+
+    version = DodontoFDist.dodontof_version(dodontof_root)
+    current_commit_id = DodontoFDist.current_commit_id(dodontof_root)
+
+    zip_filename_version = "DodontoF_Ver.#{version}.zip"
+    zip_filename_commit_id = "DodontoF_#{current_commit_id}.zip"
+
+    # 配布アーカイブに含めるファイルの準備
+    mkdir_p('dist')
+    Dir.chdir('dist') do
+      rm_rf('DodontoF_WebSet')
+      mkdir('DodontoF_WebSet')
+
+      Dir.chdir('DodontoF_WebSet') do
+        mkdir('public_html')
+
+        Dir.chdir('public_html') do
+          sh("git clone --recursive #{dodontof_root}/.git DodontoF")
+
+          Dir.chdir('DodontoF') do
+            sh("git checkout -b dist #{current_commit_id}")
+
+            cp("#{dodontof_root}/DodontoF.swf", '.')
+            mv('imageUploadSpace', '..')
+            mv('saveData', '../..')
+
+            zf_src_actionScript =
+              ZipFileGenerator.new('src_actionScript', 'src_actionScript.zip')
+            zf_src_actionScript.write
+
+            rm_rf(Dir.glob('.git*') + ['dist', 'src_actionScript', 'README.md'])
+          end
+
+          Dir.chdir('imageUploadSpace') do
+            mkdir('public')
+          end
+        end
+      end
+
+      puts
+      puts("[配布アーカイブのファイル名]")
+      puts("バージョン (v): #{zip_filename_version}")
+      puts("コミットID (c): #{zip_filename_commit_id}")
+
+      zip_filename = nil
+      loop do
+        print('どちらのファイル名で保存しますか? [V/c] > ')
+
+        line = $stdin.gets
+        abort unless line
+
+        case line.chomp
+        when '', 'V', 'v'
+          zip_filename = zip_filename_version
+          break
+        when 'C', 'c'
+          zip_filename = zip_filename_commit_id
+          break
+        end
+      end
+
+      rm_rf(zip_filename)
+
+      zf_dodontof = ZipFileGenerator.new('DodontoF_WebSet', zip_filename)
+      zf_dodontof.write
+    end
+  end
+end

--- a/tasks/swf.rake
+++ b/tasks/swf.rake
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+desc 'SWF ファイルを作成する'
+task :swf do
+  mxmlc = 'mxmlc'
+  options = [
+    '-target-player=10.0.12',
+    '-define=TEST::isTest,false',
+    '-define=COMPILE::isReplayer,false',
+    '-define=COMPILE::isMySql,false',
+    '-include-libraries+=./corelib/bin/corelib.swc',
+    '-o ../DodontoF.swf'
+  ]
+  input = 'DodontoF.mxml'
+  command = ([mxmlc] + options + [input]).join(' ')
+
+  Dir.chdir('src_actionScript') do
+    sh(command)
+  end
+end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+require 'rake/testtask'
+
+Rake::TestTask.new(:test_libs) do |t|
+  t.test_files = ['test_ruby/test*.rb', 'test_ruby/dodontof/**/test*.rb']
+end
+
+Rake::TestTask.new(:test_cgi) do |t|
+  t.test_files = ['test_ruby/cgi/test*.rb']
+end
+
+desc 'すべてのテストを行う'
+task :test do
+  failures = []
+
+  puts('[ライブラリのテスト]')
+  begin
+    Rake::Task['test_libs'].execute
+  rescue
+    failures << 'ライブラリ'
+  end
+
+  puts
+  puts('[CGI のテスト]')
+  begin
+    Rake::Task['test_cgi'].execute
+  rescue
+    failures << 'CGI'
+  end
+
+  unless failures.empty?
+    raise "テスト失敗: #{failures.join(', ')}"
+  end
+end

--- a/tasks/zip_recursive.rb
+++ b/tasks/zip_recursive.rb
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+# Original: https://github.com/rubyzip/rubyzip/blob/2569a655fe1c241dfdcea9d871d2fb676a9d4b85/README.md
+
+require 'zip'
+
+# This is a simple example which uses rubyzip to
+# recursively generate a zip file from the contents of
+# a specified directory. The directory itself is not
+# included in the archive, rather just its contents.
+#
+# Usage:
+#   directory_to_zip = "/tmp/input"
+#   output_file = "/tmp/out.zip"
+#   zf = ZipFileGenerator.new(directory_to_zip, output_file)
+#   zf.write()
+class ZipFileGenerator
+  # Initialize with the directory to zip and the location of the output archive.
+  def initialize(input_dir, output_file)
+    @input_dir = input_dir
+    @output_file = output_file
+  end
+
+  # Zip the input directory.
+  def write
+    ::Zip::File.open(@output_file, ::Zip::File::CREATE) do |io|
+      write_entries([@input_dir], '', io)
+    end
+
+    puts("ZIPファイル生成完了: #{@output_file}")
+  end
+
+  private
+
+  # A helper method to make the recursion work.
+  def write_entries(entries, path, io)
+    entries.each do |e|
+      zip_file_path = path == '' ? e : File.join(path, e)
+
+      if File.directory?(zip_file_path)
+        recursively_deflate_directory(zip_file_path, io)
+      else
+        put_into_archive(zip_file_path, io)
+      end
+    end
+  end
+
+  def recursively_deflate_directory(zip_file_path, io)
+    io.mkdir(zip_file_path)
+    subdir = Dir.entries(zip_file_path) - %w(. ..)
+    write_entries(subdir, zip_file_path, io)
+  end
+
+  def put_into_archive(zip_file_path, io)
+    io.get_output_stream(zip_file_path) do |f|
+      f.write(File.open(zip_file_path, 'rb').read)
+    end
+  end
+end


### PR DESCRIPTION
#77 で言及した、配布アーカイブを自動で生成するスクリプトを作りました。

※竹流さんの環境で実行できるか確認していただきたいため、仮にマージしていただける場合でも**確認後**でお願いいたします。

# 目的

* **どんな環境でもどどんとふの配布アーカイブを作れるようにする**。
    * OSに依存しない生成スクリプトをリポジトリに含めることにより、竹流さんの環境以外でも現在とほぼ同じどどんとふの配布アーカイブを作れるようにします。
    * 作成手順をスクリプトの形で明記したことで、配布アーカイブに必要なファイルを入れ忘れる、不要なファイルを含めるといったミスがなくなります。
    * ダイスボット等を追加・変更したどどんとふをテストするための新しい環境が作りやすくなります。
* **リポジトリと配布アーカイブの内容に差が出ないようにする**。
    * リポジトリの最新コミットと同じ内容を配布アーカイブに含めるようにしたため、変更履歴とリリースファイルの間に差ができることがなくなります。
    * 現在は公式サイトで過去のバージョンの配布アーカイブが消されてしまう上、必ずしもバージョンアップごとにコミットされないため、問題が発生した場合にどのバージョンで初めて発生したか追跡するのが困難です。このスクリプトを使用するようにすれば、以上の問題が（恣意的に起こさない限り）起きなくなります。
    * 上記の仕組みのため、リリースの際は必ず「**コミット→配布アーカイブ作成**」という手順になります。
        * 本題から少し外れますが、別ブランチでコミットしてGitHubにアップロードし、[Travis CI](https://travis-ci.org/torgtaitai/DodontoF)のテスト結果で問題がないことを確認後、マージするという手順にすることで、バグの検出が行いやすくなります。

# 動作環境

* Ruby 1.9.2以降
    * 依存している[rubyzip](https://github.com/rubyzip/rubyzip)ライブラリの動作に必要なバージョンです。
    * どどんとふは（主にさくらレンタルサーバーの環境のため）1.8.7以降で動作する必要がありますが、配布アーカイブの生成は1.9系以降で問題ないと判断しました。
* Git 1.6.5以降

OS非依存です。動作確認はLinux（Ubuntu 16.04）、macOS Sierra、Windows 10のそれぞれにおいて、Ruby 1.9.3、2.1.9、2.4.1を使用して行いました。

# 準備

PATH環境変数を設定し、`git` コマンドを実行できる端末（コマンドプロンプト）で作業を行います。

スクリプトで使用している[rubyzip](https://github.com/rubyzip/rubyzip)ライブラリをインストールするため、以下のいずれかを実行します。

```bash
# gemコマンドを使用する場合
gem install rubyzip

# bundlerライブラリを使用する場合
gem install bundler
cd どどんとふリポジトリのディレクトリ
bundle install
```

# 使用法

前回 `rake swf` コマンドでDodontoF.swfを生成してからActionScriptソースを変更した場合は、DodontoF.swfを削除しておきます（あるいは `rake clobber` コマンドを実行します）。

どどんとふリポジトリのディレクトリにおいて、変更のコミット後、端末で以下を実行します。

```bash
rake dist
```

以上を実行すると、どどんとふリポジトリのディレクトリ/dist 以下に、`git clone` コマンドを使用して現在のブランチの最新コミットの状態がコピーされます。そして、ファイルの移動や不要なファイルの削除が行われ、最終的に配布アーカイブに含まれるDodontoF\_WebSetディレクトリが生成されます。その後、以下のようなプロンプトが表示されます。

```
[配布アーカイブのファイル名]
バージョン (v): DodontoF_Ver.1.48.25.zip
コミットID (c): DodontoF_b43f74a.zip
どちらのファイル名で保存しますか? [V/c] >
```

バージョン（v）またはコミットID（c）を入力して改行すると、指定した名前の配布アーカイブが どどんとふリポジトリのディレクトリ/dist 内に保存されます。なお、バージョン番号は、DodontoFServer.rb内にある `DodontoF::VERSION` 定数の読み取りによって検出しています。

# 確認していただきたいこと

以下のことを確認していただきたいです。お忙しいところ恐縮ですが、よろしくお願いいたします。

* 竹流さんの環境において、上記の準備および使用法の手順で配布アーカイブを作成できるか。
* 配布アーカイブを作成できた場合、現在の配布アーカイブと比べて含まれているファイルに差がないか。
    * 手元の環境では、#76 のGemfileが含まれていること以外に差がないことを `diff` コマンドを使用して確認しました。
* 使い勝手は現在竹流さんが使われているスクリプトと比べてどうか。

なお、現在のローカルリポジトリとファイルが混ざらないようにするため、確認の際は以下のコマンドで別のディレクトリにcloneすることをお勧めします。

```bash
git clone -b rake-dist https://github.com/ochaochaocha3/DodontoF.git 保存先ディレクトリ\DodontoF-rake-dist
```
