### PR TITLE
インスタンス変数未初期化の警告が出ないようにする

### DIFF
--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -166,16 +166,14 @@ class DodontoFServer
     @saveDirInfo = saveDirInfo
 
     @logger = DodontoF::Logger.instance
-
-    roomIndexKey = "room"
-    initSaveFiles( getRequestData(roomIndexKey) )
+    @cgi = nil
 
     @jsonpCallBack = nil
     @isWebIf = false
     @isRecordEmpty = false
 
-    @diceBotTablePrefix = 'diceBotTable_'
-    @dice_adapter = DodontoF::DiceAdapter.new(getDiceBotExtraTableDirName, @diceBotTablePrefix)
+    initSaveFiles(getRequestData('room'))
+    @dice_adapter = DodontoF::DiceAdapter.new(getDiceBotExtraTableDirName, 'diceBotTable_')
 
     @fullBackupFileBaseName = "DodontoFFullBackup"
 

--- a/DodontoFServerMySqlKai.rb
+++ b/DodontoFServerMySqlKai.rb
@@ -164,15 +164,13 @@ class DodontoFServer_MySqlKai
     @saveDirInfo = saveDirInfo
 
     @logger = DodontoF::Logger.instance
-
-    roomIndexKey = "room"
-    initSaveFiles( getRequestData(roomIndexKey) )
+    @cgi = nil
 
     @jsonpCallBack = nil
     @isWebIf = false
 
-    @diceBotTablePrefix = 'diceBotTable_'
-    @dice_adapter = DodontoF::DiceAdapter.new(getDiceBotExtraTableDirName, @diceBotTablePrefix)
+    initSaveFiles(getRequestData('room'))
+    @dice_adapter = DodontoF::DiceAdapter.new(getDiceBotExtraTableDirName, 'diceBotTable_')
 
     @fullBackupFileBaseName = "DodontoFFullBackup"
 

--- a/src_ruby/saveDirInfo.rb
+++ b/src_ruby/saveDirInfo.rb
@@ -94,8 +94,6 @@ class SaveDirInfo
       return @saveDataDirIndex
     end
     
-    @logger.debug(@requestData.inspect, "requestData")
-    
     @logger.debug(@saveDataDirIndexObject, "saveDataDirIndexObject")
     
     if( @saveDataDirIndexObject.instance_of?( StringIO ) )

--- a/src_ruby/saveDirInfoMysql.rb
+++ b/src_ruby/saveDirInfoMysql.rb
@@ -90,8 +90,6 @@ class SaveDirInfo
       return @saveDataDirIndex
     end
     
-    @logger.debug(@requestData.inspect, "requestData")
-    
     @logger.debug(@saveDataDirIndexObject, "saveDataDirIndexObject")
     
     if( @saveDataDirIndexObject.instance_of?( StringIO ) )

--- a/test_ruby/test_DodontoFServer.rb
+++ b/test_ruby/test_DodontoFServer.rb
@@ -496,7 +496,7 @@ class DodontoFServerTest < Test::Unit::TestCase
     parsed['tagInfos'].each do |k,t|
       assert_equal(true, bases.include?(File.basename(k, '.*')))
     end
-   end
+  end
 
   # 'changeImageTags' => :hasNoReturn
   def test_changeImageTags


### PR DESCRIPTION
テストを実行したときに、警告が大量に出ていました（[例](https://travis-ci.org/torgtaitai/DodontoF/jobs/254418308)）。このうち大きな割合を占めていたインスタンス変数未初期化の部分を直しました。テスト結果の行数を比較すると、警告が300回程度減りました。
https://travis-ci.org/ochaochaocha3/DodontoF/jobs/254449220

* DodontoFServerの `@cgi`：初期化される前に `getRequestData('room')` で参照されていました。
* SaveDirInfo・SaveDirInfoMysqlの `@requestData`：現在は使われていないようでした。
