### PR TITLE
JSONPのリクエストの場合、Content-Typeをtext/javascriptにする。

### DIFF
--- a/DodontoFServer.rb
+++ b/DodontoFServer.rb
@@ -5757,6 +5757,7 @@ def printResult(server)
     result = server.getResponse
 
     if( server.jsonpCallBack )
+      header = "Content-Type: text/javascript\n"
       result = "#{server.jsonpCallBack}(" + result + ");";
     end
 


### PR DESCRIPTION
X-Content-Type-Options: nosniff 等のセキュリティ関連の設定に影響する変更です
参考URL：  https://wiki.mozilla.org/Security/Guidelines/Web_Security#X-Content-Type-Options

このヘッダはXSS対策として必要になるヘッダなのですが、この設定を指定した場合に、
callbackを指定したwebifのレスポンスのContent-Typeがapplication/jsonであるために、
ブラウザがJavascriptとして実行してくれず、例えばどろいどんとふで表示ができなくなってしまいます。
その対策として、callbackが指定されている場合にはContent-Typeをtext/javascriptとする変更です。