### PR TITLE
changePlayRoomコマンドのパスワードの処理を変更

### DIFF
--- a/src_actionScript/SharedDataReceiver.as
+++ b/src_actionScript/SharedDataReceiver.as
@@ -387,6 +387,7 @@ package {
                                                          playRoomInfo.backgroundImage,
                                                          playRoomInfo.gameType,
                                                          playRoomInfo.viewStateInfo);
+            DodontoF_Main.getInstance().setPlayRoomPassword( playRoomInfo.playRoomChangedPassword);
             
             Log.logging("analyzePlayRoomInfo end");
         }

--- a/src_ruby/dodontof/play_room.rb
+++ b/src_ruby/dodontof/play_room.rb
@@ -105,7 +105,7 @@ module DodontoF
 
         @server.changeSaveData(trueSaveFileName) do |saveData|
           saveData['playRoomName'] = params['playRoomName']
-          saveData['playRoomChangedPassword'] = playRoomChangedPassword
+          saveData['playRoomChangedPassword'] = playRoomChangedPassword unless(saveData['playRoomChangedPassword'] == playRoomPassword)
           saveData['chatChannelNames'] = params['chatChannelNames']
           saveData['canUseExternalImage'] = params['canUseExternalImage']
           saveData['canVisit'] = params['canVisit']

--- a/src_ruby/dodontof_mysqlkai/play_room.rb
+++ b/src_ruby/dodontof_mysqlkai/play_room.rb
@@ -116,7 +116,7 @@ module DodontoF_MySqlKai
         changePlayRoomData do |saveData|
           @logger.debug(saveData, 'changePlayRoom() saveData before')
           saveData['playRoomName'] = params['playRoomName']
-          saveData['playRoomChangedPassword'] = playRoomChangedPassword
+          saveData['playRoomChangedPassword'] = playRoomChangedPassword unless(saveData['playRoomChangedPassword'] == playRoomPassword)
           saveData['chatChannelNames'] = params['chatChannelNames']
           saveData['canUseExternalImage'] = params['canUseExternalImage']
           saveData['canVisit'] = params['canVisit']


### PR DESCRIPTION
ユーザーがログイン中のプレイルームのパスワードが変更された場合、
パスワードの入力欄の値をサーバーから通知されたcrypt済みの値に変更します。

プレイルームの情報をchangePlayRoomコマンドで変更した時に、
新しいパスワードとcrypt済みのパスワードの文字列が一致した場合、
ユーザーはパスワードの内容を変更していないのでプレイルームのパスワードを変更しません。